### PR TITLE
Fixed incorrect durations being fed to Linear construction

### DIFF
--- a/src/bloqade/builder/waveform.py
+++ b/src/bloqade/builder/waveform.py
@@ -21,7 +21,7 @@ class Waveform(Builder):
 
     def piecewise_linear(self, durations: List[ScalarType], values: List[ScalarType]):
         builder = self
-        for duration, start, stop in zip(durations, values[:-1], values[1:]):
+        for duration, start, stop in zip(durations[1:], values[:-1], values[1:]):
             builder = builder.linear(start, stop, duration)
 
         return builder


### PR DESCRIPTION
The current `piecewise_linear` method in the builder would set the duration to 0 for the first `Linear` it generates if the first value of the `durations` list that gets passed in isn't offset by one. I've corrected this with a simple slicing operation akin to what's already done with `values`. 