### PR TITLE
Converting to Braket `AnalogHamiltonianSimulation`

### DIFF
--- a/src/bloqade/submission/ir/braket.py
+++ b/src/bloqade/submission/ir/braket.py
@@ -60,7 +60,7 @@ def extract_braket_program(quera_task_ir: QuEraTaskSpecification):
         quera_task_ir.effective_hamiltonian.rydberg.rabi_frequency_amplitude.global_
     )
     rabi_phase = (
-        quera_task_ir.effective_hamiltonian.rydberg.rabi_frequency_amplitude.global_
+        quera_task_ir.effective_hamiltonian.rydberg.rabi_frequency_phase.global_
     )
     global_detuning = quera_task_ir.effective_hamiltonian.rydberg.detuning.global_
     local_detuning = quera_task_ir.effective_hamiltonian.rydberg.detuning.local


### PR DESCRIPTION
Currently there is no support for Braket program in when using their device much like the simulator. I will open a PR later to support this but in the mean time we should just use AnalogHamiltonianSimulation only when submitting to Braket.