### PR TITLE
Allow forwarding of kwargs for Scipy ODE solver options

### DIFF
--- a/src/bloqade/task/braket_simulator.py
+++ b/src/bloqade/task/braket_simulator.py
@@ -25,9 +25,9 @@ from collections import OrderedDict
 class BraketEmulatorTask(BaseModel, Task):
     task_ir: BraketTaskSpecification
 
-    def submit(self) -> "BraketEmulatorTaskFuture":
+    def submit(self, **kwargs) -> "BraketEmulatorTaskFuture":
         aws_task = LocalSimulator("braket_ahs").run(
-            self.task_ir.program, shots=self.task_ir.nshots
+            self.task_ir.program, shots=self.task_ir.nshots, **kwargs
         )
 
         return BraketEmulatorTaskFuture(
@@ -84,15 +84,13 @@ class BraketEmulatorJob(JSONInterface, Job):
                 )
 
     def submit(
-        self,
-        multiprocessing: bool = False,
-        max_workers: Optional[int] = None,
+        self, multiprocessing: bool = False, max_workers: Optional[int] = None, **kwargs
     ) -> Future:
         if multiprocessing:
             futures = {}
             with ProcessPoolExecutor(max_workers=max_workers) as executor:
                 for task_number, task in self.tasks.items():
-                    futures[task_number] = executor.submit(task.submit)
+                    futures[task_number] = executor.submit(task.submit, **kwargs)
 
             return self._emit_future(
                 {


### PR DESCRIPTION
The AWS Braket SDK default local emulator uses the scipy `zvode` integrator with an `adams` as a solver for non-stiff systems. Unfortunately this falls apart for simulation of quantum scar dynamics which either crashes OR shows strong oscillations characteristic of a stiff system in the solution. 

A solution to this is to set the solver to `bdf` (as well as lower the order), which requires allowing the user to pass arguments to the integrator (credit to @weinbe58 for this). With the forwarding of `kwargs` here a user can also specify: `order, nsteps, first_step, max_step, min_step`. 