### PR TITLE
Fix slice visitor

### DIFF
--- a/src/bloqade/codegen/hardware/quera.py
+++ b/src/bloqade/codegen/hardware/quera.py
@@ -134,7 +134,7 @@ class PiecewiseLinearCodeGen(WaveformVisitor):
             )
 
         if start_time == stop_time:
-            return [Decimal(0, 0), Decimal(0.0)], [Decimal(0.0), Decimal(0.0)]
+            return [Decimal(0.0), Decimal(0.0)], [Decimal(0.0), Decimal(0.0)]
 
         times, values = self.visit(ast.waveform)
 


### PR DESCRIPTION
`Decimal(0, 0)` is not a value constructor (or time value). Most likely a typo.