### PR TITLE
Fix Discretization

### DIFF
--- a/src/bloqade/submission/ir/task_specification.py
+++ b/src/bloqade/submission/ir/task_specification.py
@@ -14,7 +14,7 @@ FloatType = Union[Decimal, float]
 
 def discretize_list(list_of_values: list, resolution: FloatType):
     resolution = Decimal(str(float(resolution)))
-    return [Decimal(value).quantize(resolution) for value in list_of_values]
+    return [round(Decimal(value) / resolution) * resolution for value in list_of_values]
 
 
 class GlobalField(BaseModel):


### PR DESCRIPTION
Found an issue in testing #221 where the `discretize_list` function that gets called on the detuning values generated from sampling failed to produce values that were integer multiples of the detuning resolution. 

@weinbe58 dug up the new Braket SDK implementation of this that avoids this problem (the existing implementation in bloqade-python was based off a potentially older version of the Braket SDK approach).