### PR TITLE
Fix Missing `QUEUED` status code translation

### DIFF
--- a/src/bloqade/submission/ir/braket.py
+++ b/src/bloqade/submission/ir/braket.py
@@ -131,7 +131,7 @@ def from_braket_status_codes(braket_message: str) -> QuEraTaskStatusCode:
 
         case str("CANCELLED"):
             return QuEraTaskStatusCode.Cancelled
-        
+
         case str("QUEUED"):
             return QuEraTaskStatusCode.Enqueued
 


### PR DESCRIPTION
`from_braket_status_codes` does not return `QuEraStatusCode.Enqueued` and causes certain report methods to fail (versus returning empty results) for tasks that are queued.