### PR TITLE
Fix no lattice bug when getting bitstrings

### DIFF
--- a/src/bloqade/task/base.py
+++ b/src/bloqade/task/base.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 class Geometry:
     sites: List[Tuple[float, float]]
     filling: List[int]
-    parallel_decoder: Optional[ParallelDecoder]
+    parallel_decoder: Optional[ParallelDecoder] = None
 
 
 TaskSubType = TypeVar("TaskSubType", bound="Task")

--- a/src/bloqade/task/braket_simulator.py
+++ b/src/bloqade/task/braket_simulator.py
@@ -18,8 +18,8 @@ class BraketEmulatorTask(JSONInterface, Task):
 
     def _geometry(self) -> Geometry:
         return Geometry(
-            sites=self.task_ir.lattice.sites,
-            filling=self.task_ir.lattice.filling,
+            sites=self.task_ir.program.setup.ahs_register.sites,
+            filling=self.task_ir.program.setup.ahs_register.filling,
         )
 
     def submit(self, **kwargs) -> "BraketEmulatorTaskResults":


### PR DESCRIPTION
This PR fix issues #336, and related examples:


1. Braket IR does not have `lattice` anymore. instead, `program.ahs_register` is used. 
