### PR TITLE
Make sure `Rectangular` pretty printing follows the same format

### DIFF
--- a/src/bloqade/ir/location/bravais.py
+++ b/src/bloqade/ir/location/bravais.py
@@ -294,7 +294,7 @@ class Rectangular(BoundedBravais):
             pltxt.xlabel("x (um)")
             pltxt.ylabel("y (um)")
 
-            pltxt.scatter(xs, ys, color="magenta")
+            pltxt.scatter(xs, ys, color=(100, 55, 255), marker="dot")
 
             return pltxt.build()
 


### PR DESCRIPTION
Caught something I left out where the marker and colors for `Rectangular` pretty printing don't adhere to the same theme as other plots.

This should be merged in before #402 so I can generate some new unit tests for `Rectangular` repr.