### PR TITLE
Various bugs in Emulator.

### DIFF
--- a/src/bloqade/builder/waveform.py
+++ b/src/bloqade/builder/waveform.py
@@ -789,7 +789,7 @@ class Poly(WaveformPrimitive):
         parent: Optional[Builder] = None,
     ) -> None:
         super().__init__(parent)
-        self._coeffs = map(ir.cast, coeffs)
+        self._coeffs = ir.cast(coeffs)
         self._duration = ir.cast(duration)
 
     def __bloqade_ir__(self):

--- a/src/bloqade/emulate/codegen/emulator_ir.py
+++ b/src/bloqade/emulate/codegen/emulator_ir.py
@@ -152,7 +152,7 @@ class EmulatorProgramCodeGen(AnalogCircuitVisitor):
 
         terms = []
 
-        if len(ast.value) < self.n_atoms:
+        if len(ast.value) <= self.n_atoms:
             for sm, wf in ast.value.items():
                 self.duration = max(
                     float(wf.duration(**self.assignments)), self.duration
@@ -196,7 +196,7 @@ class EmulatorProgramCodeGen(AnalogCircuitVisitor):
         if amplitude is None:
             return terms
 
-        if phase is None and len(amplitude.value) < self.n_atoms:
+        if phase is None and len(amplitude.value) <= self.n_atoms:
             for sm, wf in amplitude.value.items():
                 self.duration = max(
                     float(wf.duration(**self.assignments)), self.duration
@@ -239,7 +239,7 @@ class EmulatorProgramCodeGen(AnalogCircuitVisitor):
         elif (
             len(phase.value) == 1
             and UniformModulation() in phase.value
-            and len(amplitude.value) < self.n_atoms
+            and len(amplitude.value) <= self.n_atoms
         ):
             (phase_waveform,) = phase.value.values()
             rabi_phase = self.waveform_compiler.emit(phase_waveform)

--- a/src/bloqade/emulate/codegen/emulator_ir.py
+++ b/src/bloqade/emulate/codegen/emulator_ir.py
@@ -210,30 +210,6 @@ class EmulatorProgramCodeGen(AnalogCircuitVisitor):
                         amplitude=self.waveform_compiler.emit(wf),
                     )
                 )
-        elif (
-            len(phase.value) == 1
-            and UniformModulation() in phase.value
-            and len(amplitude.value) < self.n_atoms
-        ):
-            (phase_waveform,) = phase.value.values()
-            rabi_phase = self.waveform_compiler.emit(phase_waveform)
-            self.duration = max(
-                float(phase_waveform.duration(**self.assignments)), self.duration
-            )
-            for sm, wf in amplitude.value.items():
-                self.duration = max(
-                    float(wf.duration(**self.assignments)), self.duration
-                )
-                terms.append(
-                    RabiTerm(
-                        operator_data=RabiOperatorData(
-                            target_atoms=self.visit(sm),
-                            operator_type=RabiOperatorType.RabiAsymmetric,
-                        ),
-                        amplitude=self.waveform_compiler.emit(wf),
-                        phase=rabi_phase,
-                    )
-                )
         elif phase is None:  # fully local real rabi fields
             amplitude_target_atoms_dict = {
                 sm: self.visit(sm) for sm in amplitude.value.keys()
@@ -258,6 +234,30 @@ class EmulatorProgramCodeGen(AnalogCircuitVisitor):
                             operator_type=RabiOperatorType.RabiSymmetric,
                         ),
                         amplitude=self.waveform_compiler.emit(amplitude_wf),
+                    )
+                )
+        elif (
+            len(phase.value) == 1
+            and UniformModulation() in phase.value
+            and len(amplitude.value) < self.n_atoms
+        ):
+            (phase_waveform,) = phase.value.values()
+            rabi_phase = self.waveform_compiler.emit(phase_waveform)
+            self.duration = max(
+                float(phase_waveform.duration(**self.assignments)), self.duration
+            )
+            for sm, wf in amplitude.value.items():
+                self.duration = max(
+                    float(wf.duration(**self.assignments)), self.duration
+                )
+                terms.append(
+                    RabiTerm(
+                        operator_data=RabiOperatorData(
+                            target_atoms=self.visit(sm),
+                            operator_type=RabiOperatorType.RabiAsymmetric,
+                        ),
+                        amplitude=self.waveform_compiler.emit(wf),
+                        phase=rabi_phase,
                     )
                 )
         else:

--- a/src/bloqade/ir/routine/braket.py
+++ b/src/bloqade/ir/routine/braket.py
@@ -147,7 +147,7 @@ class BraketHardwareRoutine(RoutineBase):
     @beartype
     def __call__(
         self,
-        *args: Tuple[LiteralType, ...],
+        *args: LiteralType,
         shots: int = 1,
         name: Optional[str] = None,
         shuffle: bool = False,
@@ -263,7 +263,7 @@ class BraketLocalEmulatorRoutine(RoutineBase):
     @beartype
     def __call__(
         self,
-        *args: Tuple[LiteralType, ...],
+        *args: LiteralType,
         shots: int = 1,
         name: Optional[str] = None,
         multiprocessing: bool = False,

--- a/src/bloqade/ir/routine/quera.py
+++ b/src/bloqade/ir/routine/quera.py
@@ -134,7 +134,7 @@ class QuEraHardwareRoutine(RoutineBase):
     @beartype
     def __call__(
         self,
-        *args: float,
+        *args: LiteralType,
         shots: int = 1,
         name: Optional[str] = None,
         shuffle: bool = False,

--- a/src/bloqade/ir/scalar.py
+++ b/src/bloqade/ir/scalar.py
@@ -185,7 +185,7 @@ class Scalar:
             new_exprs = set()
             for expr in exprs:
                 if isinstance(expr, op):
-                    exprs = map(Scalar.canonicalize, exprs)
+                    exprs = list(map(Scalar.canonicalize, exprs))
                     new_exprs.update(exprs)
                 else:
                     expr = Scalar.canonicalize(expr)


### PR DESCRIPTION
Playing around with this, making a hybrid example below, I found some bugs in the builder as well as type hints for the routines. 

```python
from bloqade import start, cast
import numpy as np
from scipy.optimize import minimize
from decimal import Decimal

dt = Decimal("0.5")
durations = cast([dt for _ in range(int(Decimal(4.0)/dt))])
detuning_coeff = [f"r{i}" for i in range(len(durations)+1)]

def cost_function(params, program):
    params = params.tolist()
    print(" ".join(f"{param:.5e}" for param in params))
    report = program(*params, shots=1000, solver_name="lsoda").report()
    bitstrings, = report.bitstrings()
    return (0.5 - np.mean(bitstrings))**2
    

program = (
    start.add_position((0,0))
    .rydberg.detuning.uniform.piecewise_linear(durations,detuning_coeff)
    .amplitude.uniform.piecewise_linear([0.1, sum(durations) - 0.2, 0.1],[0,10,10,0])
    .flatten(detuning_coeff)
    .bloqade.python()
    # .braket.local_emulator()
)
bounds = [(-100, 100) for _ in detuning_coeff]

x0 = [0 for bound in bounds]

result = minimize(cost_function, x0, method="COBYLA", args=(program,), tol=1e-12)

print(result)
```

