### PR TITLE
574 documentation fails to deploy for tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,26 @@ env:
   PDM_DEPS: 'urllib3<2'
 
 jobs:
+  pre_job:
+    # continue-on-error: true # Uncomment once integration is finished
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          # All of these options are optional, so you can remove them if you are happy with the defaults
+          concurrent_skipping: 'never'
+          skip_after_successful_duplicate: 'true'
+          paths_ignore: '["**/README.md", "**/docs/**","**/conda.recipe/**"]'
+          do_not_skip: '["workflow_dispatch", "schedule"]'
+
+
   build:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/deploy_latest.yml
+++ b/.github/workflows/deploy_latest.yml
@@ -17,6 +17,13 @@ jobs:
     name: Deploy release documentation
     runs-on: ubuntu-latest
     steps:
+      - name: Wait for Dev documentation to deploy
+        uses: lewagon/wait-on-check-action@v1.3.1
+        with:
+          ref: main
+          check-name: 'Deploy dev documentation'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
1. Adding `pre_job` for CI 
2. Adding workflow step in deployment of `latest` that polls the `dev` deployment status and waits until dev is deployed before running `latest` deployment. This should hopefully fix the race condition. 