### PR TITLE
Fixing serialization import issue

### DIFF
--- a/src/bloqade/codegen/common/json.py
+++ b/src/bloqade/codegen/common/json.py
@@ -489,7 +489,5 @@ class BloqadeIRDeserializer:
             ((head, options),) = obj.items()
             if head in cls.constructors:
                 return cls.constructors[head](**options)
-            else:
-                return obj
 
         return obj

--- a/src/bloqade/codegen/common/json.py
+++ b/src/bloqade/codegen/common/json.py
@@ -88,7 +88,12 @@ class WaveformSerializer(WaveformVisitor):
         self.scalar_encoder = ScalarSerilaizer()
 
     def visit_constant(self, ast: waveform.Constant) -> Dict[str, Any]:
-        return {"constant": {"value": self.scalar_encoder.visit(ast.value)}}
+        return {
+            "constant": {
+                "value": self.scalar_encoder.visit(ast.value),
+                "duration": self.scalar_encoder.visit(ast.duration),
+            }
+        }
 
     def visit_linear(self, ast: waveform.Linear) -> Dict[str, Any]:
         return {
@@ -484,4 +489,7 @@ class BloqadeIRDeserializer:
             ((head, options),) = obj.items()
             if head in cls.constructors:
                 return cls.constructors[head](**options)
+            else:
+                return obj
+
         return obj

--- a/src/bloqade/emulate/ir/emulator.py
+++ b/src/bloqade/emulate/ir/emulator.py
@@ -28,7 +28,10 @@ def _serialize(obj: CompiledWaveform) -> Dict[str, Any]:
 
 @CompiledWaveform.set_deserializer
 def _deserializer(d: Dict[str, Any]) -> CompiledWaveform:
-    d["source"] = BloqadeIRDeserializer.object_hook(d["source"])
+    from json import loads, dumps
+
+    source_str = dumps(d["source"])
+    d["source"] = loads(source_str, object_hook=BloqadeIRDeserializer.object_hook)
     return CompiledWaveform(**d)
 
 

--- a/src/bloqade/serialize.py
+++ b/src/bloqade/serialize.py
@@ -4,6 +4,30 @@ from beartype.typing import Type, Callable, Dict, Union, TextIO
 from beartype import beartype
 
 
+__bloqade_package_loaded__ = False
+
+
+def load_patchage():
+    import pkgutil
+    import os
+
+    # call this function to load all modules in this package
+    # required because if no other modules are imported, the
+    # Various classes will not be registered with Serializer
+    # and the serialization will fail. only need to call this
+    # function once per process hence the flag to prevent
+    # multiple calls
+
+    if not __bloqade_package_loaded__:
+        path = os.path.abspath(os.path.join(os.path.dirname(__file__)))
+
+        for loader, module_name, _ in pkgutil.walk_packages([path]):
+            _module = loader.find_module(module_name).load_module(module_name)
+            globals()[module_name] = _module
+
+        globals()["__bloqade_package_loaded__"] = True
+
+
 class Serializer(json.JSONEncoder):
     types = ()
     type_to_str = {}
@@ -79,6 +103,7 @@ def loads(s: str, use_decimal: bool = True, **json_kwargs):
     Returns:
         Any: the deserialized object
     """
+    load_patchage()
     return json.loads(
         s, object_hook=Serializer.object_hook, use_decimal=use_decimal, **json_kwargs
     )
@@ -96,6 +121,7 @@ def load(fp: Union[TextIO, str], use_decimal: bool = True, **json_kwargs):
     Returns:
         Any: the deserialized object
     """
+    load_patchage()
     if isinstance(fp, str):
         with open(fp, "r") as f:
             return json.load(
@@ -129,6 +155,7 @@ def dumps(
     Returns:
         str: the serialized object as a string
     """
+    load_patchage()
     if not isinstance(o, Serializer.types):
         raise TypeError(
             f"Object of type {type(o)} is not JSON serializable. "
@@ -155,6 +182,7 @@ def save(
     Returns:
         None
     """
+    load_patchage()
     if not isinstance(o, Serializer.types):
         raise TypeError(
             f"Object of type {type(o)} is not JSON serializable. "

--- a/src/bloqade/serialize.py
+++ b/src/bloqade/serialize.py
@@ -155,7 +155,6 @@ def dumps(
     Returns:
         str: the serialized object as a string
     """
-    load_patchage()
     if not isinstance(o, Serializer.types):
         raise TypeError(
             f"Object of type {type(o)} is not JSON serializable. "
@@ -182,7 +181,6 @@ def save(
     Returns:
         None
     """
-    load_patchage()
     if not isinstance(o, Serializer.types):
         raise TypeError(
             f"Object of type {type(o)} is not JSON serializable. "

--- a/src/bloqade/submission/ir/parallel.py
+++ b/src/bloqade/submission/ir/parallel.py
@@ -55,7 +55,7 @@ class ParallelDecoder(BaseModel):
         )
 
     # should work if we go to the coordinate-based indexing system
-    @validator("mapping")
+    @validator("mapping", allow_reuse=True)
     def sites_belong_to_unqiue_cluster(cls, mapping):
         sites = [ele.global_location_index for ele in mapping]
         unique_sites = set(sites)

--- a/tests/test_batch2.py
+++ b/tests/test_batch2.py
@@ -39,6 +39,7 @@ def test_serializer():
         .rydberg.detuning.uniform.piecewise_linear(
             [0.1, 0.5, 0.1], [1.0, 2.0, 3.0, 4.0]
         )
+        .constant(4.0, 1)
         .braket.local_emulator()
         .run(1)
     )


### PR DESCRIPTION
Because we're using decorators the Serializer is only updated when the package components are loaded. 

If you are just wanted to load in a batch object this is problematic because you do not need to import anything to do this, for example:

```python
from bloqade import load

batch = load("my-batch.json")

batch.fetch() 
batch.report()
...
```

This will not deserialize the object because the module `task` is not imported.

My solution to this problem is to simply walk the entire package and import the modules if someone calls `load`/`loads` functions. Because this is pretty expensive I only do this if someone calls the `load`/`loads` function because that is the case were the required classes potentially hasn't been registered by the Serializer yet, while for `save`/`dump` won't have this issue because the objects had to have been created to dump them to a string. 




