### PR TITLE
Rounding errors when using `Record` node. 

### DIFF
--- a/src/bloqade/codegen/common/assignment_scan.py
+++ b/src/bloqade/codegen/common/assignment_scan.py
@@ -26,7 +26,7 @@ class AssignmentScanRecord(WaveformVisitor):
     def visit_record(self, ast: waveform.Record):
         duration = ast.waveform.duration(**self.assignments)
         var = ast.var
-        value = ast.waveform(duration, **self.assignments)
+        value = ast.waveform.eval_decimal(duration, **self.assignments)
         self.assignments[var.name] = value
         self.visit(ast.waveform)
 


### PR DESCRIPTION
When fixing up the assignments with the `Record` node in the AST, the original implementation used the `float` version of the waveform eval which causes rounding errors when trying to generate schemas. switching to evaluating waveform using `Decimal` to fix this issue. 