### PR TITLE
Fetch fix. 

### DIFF
--- a/src/bloqade/submission/ir/task_results.py
+++ b/src/bloqade/submission/ir/task_results.py
@@ -26,6 +26,7 @@ class QuEraTaskStatusCode(str, Enum):
     Accepted = "Accepted"
     Unaccepted = "Unaccepted"
     Partial = "Partial"
+    Unsubmitted = "Unsubmitted"
 
 
 class QuEraShotResult(BaseModel):

--- a/src/bloqade/task/batch.py
+++ b/src/bloqade/task/batch.py
@@ -406,7 +406,7 @@ class RemoteBatch(Serializable):
 
         new_task_results = OrderedDict()
         for task_number, task in self.tasks.items():
-            if task._result_exists():
+            if task.task_result_ir is not None:
                 if task.task_result_ir.task_status in st_codes:
                     new_task_results[task_number] = task
 
@@ -427,7 +427,7 @@ class RemoteBatch(Serializable):
 
         new_results = OrderedDict()
         for task_number, task in self.tasks.items():
-            if task._result_exists():
+            if task.task_result_ir is not None:
                 if task.task_result_ir.task_status in st_codes:
                     continue
 

--- a/src/bloqade/task/batch.py
+++ b/src/bloqade/task/batch.py
@@ -240,14 +240,6 @@ class RemoteBatch(Serializable):
         # online, non-blocking
         # pull the results only when its ready
         for task in self.tasks.values():
-            if task.task_id is None and task._result_exists():
-                # this corresponds to a task that failed to submit.
-                # we should not fetch it. This will error out.
-                # and prevent the batch from being fetched.
-                # only if the batch was compiled but not submitted
-                # we should error out.
-                continue
-
             task.fetch()
 
         return self
@@ -291,10 +283,9 @@ class RemoteBatch(Serializable):
 
             dat = [None, None, None]
             dat[0] = task.task_id
-            if task.task_id is not None:
-                if task.task_result_ir is not None:
-                    dat[1] = task.task_result_ir.task_status.name
-                    dat[2] = task.task_ir.nshots
+            if task.task_result_ir is not None:
+                dat[1] = task.task_result_ir.task_status.name
+                dat[2] = task.task_ir.nshots
             data.append(dat)
 
         return pd.DataFrame(data, index=tid, columns=["task ID", "status", "shots"])

--- a/src/bloqade/task/batch.py
+++ b/src/bloqade/task/batch.py
@@ -406,9 +406,8 @@ class RemoteBatch(Serializable):
 
         new_task_results = OrderedDict()
         for task_number, task in self.tasks.items():
-            if task.task_result_ir is not None:
-                if task.task_result_ir.task_status in st_codes:
-                    new_task_results[task_number] = task
+            if task.task_result_ir.task_status in st_codes:
+                new_task_results[task_number] = task
 
         return RemoteBatch(self.source, new_task_results, name=self.name)
 
@@ -427,9 +426,8 @@ class RemoteBatch(Serializable):
 
         new_results = OrderedDict()
         for task_number, task in self.tasks.items():
-            if task.task_result_ir is not None:
-                if task.task_result_ir.task_status in st_codes:
-                    continue
+            if task.task_result_ir.task_status in st_codes:
+                continue
 
             new_results[task_number] = task
 

--- a/src/bloqade/task/braket.py
+++ b/src/bloqade/task/braket.py
@@ -8,7 +8,7 @@ from bloqade.submission.braket import BraketBackend
 from bloqade.submission.base import ValidationError
 from bloqade.submission.ir.task_results import QuEraTaskResults, QuEraTaskStatusCode
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from beartype.typing import Dict, Optional, Any
 
 
@@ -23,8 +23,10 @@ class BraketTask(RemoteTask):
     task_ir: QuEraTaskSpecification
     metadata: Dict[str, ParamType]
     parallel_decoder: Optional[ParallelDecoder] = None
-    task_result_ir: QuEraTaskResults = QuEraTaskResults(
-        task_status=QuEraTaskStatusCode.Unsubmitted
+    task_result_ir: QuEraTaskResults = field(
+        default_factory=lambda: QuEraTaskResults(
+            task_status=QuEraTaskStatusCode.Unsubmitted
+        )
     )
 
     def submit(self, force: bool = False) -> "BraketTask":

--- a/src/bloqade/task/braket.py
+++ b/src/bloqade/task/braket.py
@@ -23,7 +23,9 @@ class BraketTask(RemoteTask):
     task_ir: QuEraTaskSpecification
     metadata: Dict[str, ParamType]
     parallel_decoder: Optional[ParallelDecoder] = None
-    task_result_ir: Optional[QuEraTaskResults] = None
+    task_result_ir: QuEraTaskResults = QuEraTaskResults(
+        task_status=QuEraTaskStatusCode.Unsubmitted
+    )
 
     def submit(self, force: bool = False) -> "BraketTask":
         if not force:
@@ -47,10 +49,10 @@ class BraketTask(RemoteTask):
 
     def fetch(self) -> "BraketTask":
         # non-blocking, pull only when its completed
-        if self.task_id is None and self.task_result_ir is None:
+        if self.task_result_ir.task_status is QuEraTaskStatusCode.Unsubmitted:
             raise ValueError("Task ID not found.")
 
-        if self.task_result_ir is not None and self.task_result_ir.task_status in [
+        if self.task_result_ir.task_status in [
             QuEraTaskStatusCode.Completed,
             QuEraTaskStatusCode.Partial,
             QuEraTaskStatusCode.Failed,

--- a/src/bloqade/task/braket.py
+++ b/src/bloqade/task/braket.py
@@ -47,11 +47,20 @@ class BraketTask(RemoteTask):
 
     def fetch(self) -> "BraketTask":
         # non-blocking, pull only when its completed
-        if self.task_id is None:
+        if self.task_id is None and self.task_result_ir is None:
             raise ValueError("Task ID not found.")
 
+        if self.task_result_ir is not None and self.task_result_ir.task_status in [
+            QuEraTaskStatusCode.Completed,
+            QuEraTaskStatusCode.Partial,
+            QuEraTaskStatusCode.Failed,
+            QuEraTaskStatusCode.Unaccepted,
+            QuEraTaskStatusCode.Cancelled,
+        ]:
+            return self
+
         status = self.status()
-        if status == QuEraTaskStatusCode.Completed:
+        if status in [QuEraTaskStatusCode.Completed, QuEraTaskStatusCode.Partial]:
             self.task_result_ir = self.backend.task_results(self.task_id)
         else:
             self.task_result_ir = QuEraTaskResults(task_status=status)

--- a/src/bloqade/task/braket.py
+++ b/src/bloqade/task/braket.py
@@ -106,9 +106,6 @@ class BraketTask(RemoteTask):
         )
 
     def _result_exists(self) -> bool:
-        if self.task_id is None:
-            return False
-
         if self.task_result_ir is None:
             return False
         else:

--- a/src/bloqade/task/quera.py
+++ b/src/bloqade/task/quera.py
@@ -48,11 +48,20 @@ class QuEraTask(RemoteTask):
 
     def fetch(self) -> "QuEraTask":
         # non-blocking, pull only when its completed
-        if self.task_id is None:
+        if self.task_id is None and self.task_result_ir is None:
             raise ValueError("Task ID not found.")
 
+        if self.task_result_ir is not None and self.task_result_ir.task_status in [
+            QuEraTaskStatusCode.Completed,
+            QuEraTaskStatusCode.Partial,
+            QuEraTaskStatusCode.Failed,
+            QuEraTaskStatusCode.Unaccepted,
+            QuEraTaskStatusCode.Cancelled,
+        ]:
+            return self
+
         status = self.status()
-        if status == QuEraTaskStatusCode.Completed:
+        if status in [QuEraTaskStatusCode.Completed, QuEraTaskStatusCode.Partial]:
             self.task_result_ir = self.backend.task_results(self.task_id)
         else:
             self.task_result_ir = QuEraTaskResults(task_status=status)

--- a/src/bloqade/task/quera.py
+++ b/src/bloqade/task/quera.py
@@ -23,7 +23,9 @@ class QuEraTask(RemoteTask):
     task_ir: QuEraTaskSpecification
     metadata: Dict[str, ParamType]
     parallel_decoder: Optional[ParallelDecoder] = None
-    task_result_ir: Optional[QuEraTaskResults] = None
+    task_result_ir: QuEraTaskResults = QuEraTaskResults(
+        task_status=QuEraTaskStatusCode.Unsubmitted
+    )
 
     def submit(self, force: bool = False) -> "QuEraTask":
         if not force:
@@ -48,10 +50,10 @@ class QuEraTask(RemoteTask):
 
     def fetch(self) -> "QuEraTask":
         # non-blocking, pull only when its completed
-        if self.task_id is None and self.task_result_ir is None:
+        if self.task_result_ir.task_status is QuEraTaskStatusCode.Unsubmitted:
             raise ValueError("Task ID not found.")
 
-        if self.task_result_ir is not None and self.task_result_ir.task_status in [
+        if self.task_result_ir.task_status in [
             QuEraTaskStatusCode.Completed,
             QuEraTaskStatusCode.Partial,
             QuEraTaskStatusCode.Failed,

--- a/src/bloqade/task/quera.py
+++ b/src/bloqade/task/quera.py
@@ -11,7 +11,7 @@ from bloqade.submission.quera import QuEraBackend
 
 from beartype.typing import Dict, Optional, Union, Any
 from bloqade.builder.base import ParamType
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import warnings
 
 
@@ -23,8 +23,10 @@ class QuEraTask(RemoteTask):
     task_ir: QuEraTaskSpecification
     metadata: Dict[str, ParamType]
     parallel_decoder: Optional[ParallelDecoder] = None
-    task_result_ir: QuEraTaskResults = QuEraTaskResults(
-        task_status=QuEraTaskStatusCode.Unsubmitted
+    task_result_ir: QuEraTaskResults = field(
+        default_factory=lambda: QuEraTaskResults(
+            task_status=QuEraTaskStatusCode.Unsubmitted
+        )
     )
 
     def submit(self, force: bool = False) -> "QuEraTask":

--- a/src/bloqade/task/quera.py
+++ b/src/bloqade/task/quera.py
@@ -107,9 +107,6 @@ class QuEraTask(RemoteTask):
         )
 
     def _result_exists(self) -> bool:
-        if self.task_id is None:
-            return False
-
         if self.task_result_ir is None:
             return False
         else:


### PR DESCRIPTION
Fetch fails to fetch results because of missing task ids

Here I change this behavior such that if the task has no ID but the `task_result_ir` is not `None` and has status `Unaccepted` we skip the fetch because this implies the job was attemped to run at least once but failed because of some issue. I also skip fetching tasks that have a terminating status, e.g. `Cancelled` or `Failed` because we know these tasks will never change that status and so we do not need to fetch that status again. 

EDIT: I am also adding a new status to the list of Task status to make it more clear what exactly is happening. By Default The task is created with a `task_result_ir` that has a status of `Unsubmitted` which will be used instead of `task_id` being None. For people who are not familiar with the behavior this will make much more sense. This is also needed because the filters do not have any method of filtering out based on the value of `task_id` so using a status is preferable here. 

A task that is successfully submitted the task status goes from `Unsubmitted` to `Enqueued` while if there is any error that occurs during the submission the status goes to `Unaccepted`. From there you use the API to get the status which updates the status in `task_result_ir`. 
