### PR TITLE
Fixing compilation route

### DIFF
--- a/src/bloqade/builder/backend/bloqade.py
+++ b/src/bloqade/builder/backend/bloqade.py
@@ -26,9 +26,7 @@ class BloqadeDeviceRoute(Builder):
             -> `...python().run(shots, ...)`
                 :: Run the current program using bloqade python backend
         """
-        routine = self.parse_source()
-
-        return routine.bloqade.python()
+        return self.parse().bloqade.python()
 
     def julia(self, solver: str, nthreads: int = 1):
         raise NotImplementedError

--- a/src/bloqade/builder/backend/bloqade.py
+++ b/src/bloqade/builder/backend/bloqade.py
@@ -26,9 +26,9 @@ class BloqadeDeviceRoute(Builder):
             -> `...python().run(shots, ...)`
                 :: Run the current program using bloqade python backend
         """
-        from bloqade.ir.routine.bloqade import BloqadeServiceOptions
+        routine = self.parse_source()
 
-        return BloqadeServiceOptions(self).python()
+        return routine.bloqade.python()
 
     def julia(self, solver: str, nthreads: int = 1):
         raise NotImplementedError

--- a/src/bloqade/builder/backend/braket.py
+++ b/src/bloqade/builder/backend/braket.py
@@ -39,7 +39,7 @@ class BraketDeviceRoute(Builder):
                 and results returned
 
         """
-        return self.parse_source().braket.aquila()
+        return self.parse().braket.aquila()
 
     def local_emulator(self):
         """
@@ -55,4 +55,4 @@ class BraketDeviceRoute(Builder):
                 :: run on local emulator
 
         """
-        return self.parse_source().braket.local_emulator()
+        return self.parse().braket.local_emulator()

--- a/src/bloqade/builder/backend/braket.py
+++ b/src/bloqade/builder/backend/braket.py
@@ -39,9 +39,7 @@ class BraketDeviceRoute(Builder):
                 and results returned
 
         """
-        from bloqade.ir.routine.base import Routine
-
-        return Routine(self).braket.aquila()
+        return self.parse_source().braket.aquila()
 
     def local_emulator(self):
         """
@@ -57,6 +55,4 @@ class BraketDeviceRoute(Builder):
                 :: run on local emulator
 
         """
-        from bloqade.ir.routine.base import Routine
-
-        return Routine(self).braket.local_emulator()
+        return self.parse_source().braket.local_emulator()

--- a/src/bloqade/builder/backend/quera.py
+++ b/src/bloqade/builder/backend/quera.py
@@ -75,9 +75,7 @@ class QuEraDeviceRoute(Builder):
 
 
         """
-        from bloqade.ir.routine.base import Routine
-
-        return Routine(self).quera.aquila()
+        return self.parse_source().quera.aquila()
 
     def cloud_mock(self):
         """
@@ -102,9 +100,7 @@ class QuEraDeviceRoute(Builder):
 
 
         """
-        from bloqade.ir.routine.base import Routine
-
-        return Routine(self).quera.cloud_mock()
+        return self.parse_source().quera.cloud_mock()
 
     def mock(self, state_file: str = ".mock_state.txt"):
         """
@@ -129,6 +125,4 @@ class QuEraDeviceRoute(Builder):
 
 
         """
-        from bloqade.ir.routine.base import Routine
-
-        return Routine(self).quera.mock(state_file)
+        return self.parse_source().quera.mock(state_file)

--- a/src/bloqade/builder/backend/quera.py
+++ b/src/bloqade/builder/backend/quera.py
@@ -48,9 +48,7 @@ class QuEraDeviceRoute(Builder):
 
 
         """
-        from bloqade.ir.routine.base import Routine
-
-        return Routine(self).quera.device(config_file, **api_config)
+        return self.parse().quera.device(config_file, **api_config)
 
     def aquila(self):
         """
@@ -75,7 +73,7 @@ class QuEraDeviceRoute(Builder):
 
 
         """
-        return self.parse_source().quera.aquila()
+        return self.parse().quera.aquila()
 
     def cloud_mock(self):
         """
@@ -100,7 +98,7 @@ class QuEraDeviceRoute(Builder):
 
 
         """
-        return self.parse_source().quera.cloud_mock()
+        return self.parse().quera.cloud_mock()
 
     def mock(self, state_file: str = ".mock_state.txt"):
         """
@@ -125,4 +123,4 @@ class QuEraDeviceRoute(Builder):
 
 
         """
-        return self.parse_source().quera.mock(state_file)
+        return self.parse().quera.mock(state_file)

--- a/src/bloqade/builder/parse/builder.py
+++ b/src/bloqade/builder/parse/builder.py
@@ -14,7 +14,8 @@ from itertools import repeat
 from typing import TYPE_CHECKING, Tuple, Union, Dict, List, Optional, Set
 
 if TYPE_CHECKING:
-    from bloqade.ir.routine.params import Params, ParamType
+    from bloqade.ir.routine.params import ParamType
+    from bloqade.ir.routine.base import Routine
     from bloqade.ir.analog_circuit import AnalogCircuit
 
 
@@ -260,9 +261,10 @@ class Parser:
 
         return circuit
 
-    def parse_source(self, builder: Builder) -> Tuple["AnalogCircuit", "Params"]:
-        from bloqade.ir.routine.params import Params
+    def parse_source(self, builder: Builder) -> "Routine":
         from bloqade.ir.analog_circuit import AnalogCircuit
+        from bloqade.ir.routine.params import Params
+        from bloqade.ir.routine.base import Routine
 
         self.reset(builder)
         self.read_register()
@@ -276,4 +278,4 @@ class Parser:
         )
         circuit = AnalogCircuit(self.register, self.sequence)
 
-        return circuit, params
+        return Routine(builder, circuit, params)

--- a/src/bloqade/builder/parse/builder.py
+++ b/src/bloqade/builder/parse/builder.py
@@ -261,7 +261,7 @@ class Parser:
 
         return circuit
 
-    def parse_source(self, builder: Builder) -> "Routine":
+    def parse(self, builder: Builder) -> "Routine":
         from bloqade.ir.analog_circuit import AnalogCircuit
         from bloqade.ir.routine.params import Params
         from bloqade.ir.routine.base import Routine

--- a/src/bloqade/builder/parse/trait.py
+++ b/src/bloqade/builder/parse/trait.py
@@ -56,7 +56,7 @@ class ParseRoutine:
     def parse_source(self: "Builder") -> "Routine":
         from bloqade.builder.parse.builder import Parser
 
-        return Parser().parse_source(self)
+        return Parser().parse(self)
 
 
 class Parse(ParseRegister, ParseSequence, ParseCircuit, ParseRoutine):
@@ -75,7 +75,7 @@ class Parse(ParseRegister, ParseSequence, ParseCircuit, ParseRoutine):
     def __repr__(self: "Builder"):
         from .builder import Parser
 
-        analog_circ, metas = Parser().parse_source(self)
+        analog_circ, metas = Parser().parse(self)
 
         return repr(analog_circ) + "\n" + repr(metas)
 

--- a/src/bloqade/builder/parse/trait.py
+++ b/src/bloqade/builder/parse/trait.py
@@ -47,13 +47,8 @@ class ParseCircuit:
 
 
 class ParseRoutine:
-    """Parse the program to return an AnalogCircuit as well as the parameters
-    for the circuit.
-
-
-    """
-
-    def parse_source(self: "Builder") -> "Routine":
+    def parse(self: "Builder") -> "Routine":
+        """Parse the program to return a Routine object."""
         from bloqade.builder.parse.builder import Parser
 
         return Parser().parse(self)

--- a/src/bloqade/builder/parse/trait.py
+++ b/src/bloqade/builder/parse/trait.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union, TYPE_CHECKING
+from beartype.typing import Union, TYPE_CHECKING
 import json
 import bloqade.ir as ir
 from bloqade.visualization import display_builder
@@ -7,7 +7,7 @@ from bloqade.visualization import display_builder
 if TYPE_CHECKING:
     from bloqade.ir import AtomArrangement, ParallelRegister, Sequence
     from bloqade.ir.analog_circuit import AnalogCircuit
-    from bloqade.ir.routine.params import Params
+    from bloqade.ir.routine.base import Routine
     from bloqade.builder.base import Builder
 
 
@@ -53,7 +53,7 @@ class ParseRoutine:
 
     """
 
-    def parse_source(self: "Builder") -> Tuple["AnalogCircuit", "Params"]:
+    def parse_source(self: "Builder") -> "Routine":
         from bloqade.builder.parse.builder import Parser
 
         return Parser().parse_source(self)

--- a/src/bloqade/ir/routine/base.py
+++ b/src/bloqade/ir/routine/base.py
@@ -26,7 +26,7 @@ class RoutineParse:
         return self.source.parse_circuit()
 
     def parse_source(self: "RoutineBase") -> Tuple[AnalogCircuit, Params]:
-        return self.source.parse_source()
+        return self.source.parse()
 
 
 @dataclass(frozen=True)

--- a/src/bloqade/ir/routine/base.py
+++ b/src/bloqade/ir/routine/base.py
@@ -7,7 +7,7 @@ from bloqade.ir.routine.params import Params
 
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Union, Tuple
+from typing import TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     from bloqade.ir.routine.braket import BraketServiceOptions
@@ -17,16 +17,16 @@ if TYPE_CHECKING:
 
 class RoutineParse:
     def parse_register(self: "RoutineBase") -> Union[AtomArrangement, ParallelRegister]:
-        return self.source.parse_register()
+        return self.circuit.register
 
     def parse_sequence(self: "RoutineBase") -> Sequence:
-        return self.source.parse_sequence()
+        return self.circuit.sequence
 
     def parse_circuit(self: "RoutineBase") -> AnalogCircuit:
-        return self.source.parse_circuit()
+        return self.circuit
 
-    def parse_source(self: "RoutineBase") -> Tuple[AnalogCircuit, Params]:
-        return self.source.parse()
+    def parse(self: "RoutineBase") -> "Routine":
+        return self
 
 
 @dataclass(frozen=True)

--- a/src/bloqade/ir/routine/base.py
+++ b/src/bloqade/ir/routine/base.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Union, Tuple
 if TYPE_CHECKING:
     from bloqade.ir.routine.braket import BraketServiceOptions
     from bloqade.ir.routine.quera import QuEraServiceOptions
+    from bloqade.ir.routine.bloqade import BloqadeServiceOptions
 
 
 class RoutineParse:
@@ -31,6 +32,8 @@ class RoutineParse:
 @dataclass(frozen=True)
 class RoutineBase(RoutineParse):
     source: Builder
+    circuit: AnalogCircuit
+    params: Params
 
 
 @dataclass(frozen=True)
@@ -41,10 +44,16 @@ class Routine(RoutineBase):
     def braket(self) -> "BraketServiceOptions":
         from .braket import BraketServiceOptions
 
-        return BraketServiceOptions(source=self.source)
+        return BraketServiceOptions(self.source, self.circuit, self.params)
 
     @property
     def quera(self) -> "QuEraServiceOptions":
         from .quera import QuEraServiceOptions
 
-        return QuEraServiceOptions(source=self.source)
+        return QuEraServiceOptions(self.source, self.circuit, self.params)
+
+    @property
+    def bloqade(self) -> "BloqadeServiceOptions":
+        from .bloqade import BloqadeServiceOptions
+
+        return BloqadeServiceOptions(self.source, self.circuit, self.params)

--- a/src/bloqade/ir/routine/bloqade.py
+++ b/src/bloqade/ir/routine/bloqade.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 @dataclass(frozen=True)
 class BloqadeServiceOptions(RoutineBase):
     def python(self):
-        return BloqadePythonRoutine(source=self.source)
+        return BloqadePythonRoutine(self.source, self.circuit, self.params)
 
 
 @dataclass(frozen=True)
@@ -29,7 +29,7 @@ class BloqadePythonRoutine(RoutineBase):
         from bloqade.emulate.codegen.hamiltonian import CompileCache
         from bloqade.task.bloqade import BloqadeTask
 
-        circuit, params = self.source.parse_source()
+        circuit, params = self.circuit, self.params
 
         circuit = AssignAnalogCircuit(params.static_params).visit(circuit)
 

--- a/src/bloqade/ir/routine/braket.py
+++ b/src/bloqade/ir/routine/braket.py
@@ -17,10 +17,10 @@ class BraketServiceOptions(RoutineBase):
         backend = BraketBackend(
             device_arn="arn:aws:braket:us-east-1::device/qpu/quera/Aquila"
         )
-        return BraketHardwareRoutine(source=self.source, backend=backend)
+        return BraketHardwareRoutine(self.source, self.circuit, self.params, backend)
 
     def local_emulator(self):
-        return BraketLocalEmulatorRoutine(source=self.source)
+        return BraketLocalEmulatorRoutine(self.source, self.circuit, self.params)
 
 
 @dataclass(frozen=True)
@@ -40,7 +40,7 @@ class BraketHardwareRoutine(RoutineBase):
 
         capabilities = self.backend.get_capabilities()
 
-        circuit, params = self.parse_source()
+        circuit, params = self.circuit, self.params
         circuit = AssignAnalogCircuit(params.static_params).visit(circuit)
 
         tasks = OrderedDict()
@@ -175,7 +175,7 @@ class BraketLocalEmulatorRoutine(RoutineBase):
         from bloqade.ir.analysis.assignment_scan import AssignmentScan
         from bloqade.submission.ir.braket import to_braket_task_ir
 
-        circuit, params = self.parse_source()
+        circuit, params = self.circuit, self.params
         circuit = AssignAnalogCircuit(params.static_params).visit(circuit)
 
         if isinstance(circuit.register, ParallelRegister):

--- a/src/bloqade/ir/routine/quera.py
+++ b/src/bloqade/ir/routine/quera.py
@@ -24,20 +24,20 @@ class QuEraServiceOptions(RoutineBase):
 
         backend = QuEraBackend(**api_config)
 
-        return QuEraHardwareRoutine(source=self.source, backend=backend)
+        return QuEraHardwareRoutine(self.source, self.circuit, self.params, backend)
 
     def aquila(self) -> "QuEraHardwareRoutine":
         backend = QuEraBackend(**load_config("Aquila"))
-        return QuEraHardwareRoutine(source=self.source, backend=backend)
+        return QuEraHardwareRoutine(self.source, self.circuit, self.params, backend)
 
     def cloud_mock(self) -> "QuEraHardwareRoutine":
         backend = QuEraBackend(**load_config("Mock"))
-        return QuEraHardwareRoutine(source=self.source, backend=backend)
+        return QuEraHardwareRoutine(self.source, self.circuit, self.params, backend)
 
     @beartype
     def mock(self, state_file: str = ".mock_state.txt") -> "QuEraHardwareRoutine":
         backend = MockBackend(state_file=state_file)
-        return QuEraHardwareRoutine(source=self.source, backend=backend)
+        return QuEraHardwareRoutine(self.source, self.circuit, self.params, backend)
 
 
 @dataclass(frozen=True)
@@ -55,7 +55,7 @@ class QuEraHardwareRoutine(RoutineBase):
         from bloqade.ir.analysis.assignment_scan import AssignmentScan
         from bloqade.codegen.hardware.quera import QuEraCodeGen
 
-        circuit, params = self.parse_source()
+        circuit, params = self.circuit, self.params
         capabilities = self.backend.get_capabilities()
         circuit = AssignAnalogCircuit(params.static_params).visit(circuit)
 

--- a/src/bloqade/visualization/display.py
+++ b/src/bloqade/visualization/display.py
@@ -69,7 +69,10 @@ def liner(txt):
 def builder_figure(builder, batch_id):
     from bloqade.builder.parse.builder import Parser
 
-    analog_circ, metas = Parser().parse_source(builder)
+    routine = Parser().parse_source(builder)
+
+    analog_circ = routine.circuit
+    metas = routine.params
 
     kwargs = metas.static_params
     kwargs.update(metas.batch_params[batch_id])

--- a/src/bloqade/visualization/display.py
+++ b/src/bloqade/visualization/display.py
@@ -69,7 +69,7 @@ def liner(txt):
 def builder_figure(builder, batch_id):
     from bloqade.builder.parse.builder import Parser
 
-    routine = Parser().parse_source(builder)
+    routine = Parser().parse(builder)
 
     analog_circ = routine.circuit
     metas = routine.params


### PR DESCRIPTION
Currently the `parse_source` returns a tuple of the circuit and the parameters. I am changing this to `parse` and allowing it to return a `Routine` object. Then the backend selection dispatches as `self.parse().service.backend()` instead of creating an intermediate routine object. Also Routine now contains the builder as well as the circuit and the parameters. 