### PR TITLE
Make Docs follow QuEra theme

### DIFF
--- a/docs/docs/stylesheets/extra.css
+++ b/docs/docs/stylesheets/extra.css
@@ -1,0 +1,4 @@
+:root {
+    --md-primary-fg-color: #6437FF;
+    --md-accent-fg-color: #6437FF;
+  }

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -74,6 +74,8 @@ theme:
         name: Switch to light mode
   favicon: assets/favicon.ico
   logo: assets/logo-dark.png
+  font:
+    text: Lato
 extra_css:
   - stylesheets/extra.css
 
@@ -100,7 +102,7 @@ plugins:
   - mkdocs-jupyter:
       include: ["*.py"] # only include scripts
       ignore: ["*.ipynb"]
-      execute: true # always execute
+      execute: false # always execute
       include_source: True
   - mike
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -102,7 +102,7 @@ plugins:
   - mkdocs-jupyter:
       include: ["*.py"] # only include scripts
       ignore: ["*.ipynb"]
-      execute: false # always execute
+      execute: true # always execute
       include_source: True
   - mike
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -61,19 +61,21 @@ theme:
     - toc.follow
   palette:
     - scheme: default
-      primary: indigo
-      accent: indigo
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
     - scheme: slate
-      primary: indigo
-      accent: indigo
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
   favicon: assets/favicon.ico
   logo: assets/logo-dark.png
+extra_css:
+  - stylesheets/extra.css
 
 plugins:
   - search:


### PR DESCRIPTION
* Set primary color to Quera colors
* Change default font to `Lato` to provide some more coherence with Bloqade.jl docs (this is the font that those docs use)

If this is approved it might be worth reflecting the changes in the examples.

<img width="1068" alt="Screenshot 2023-09-25 at 6 31 45 PM" src="https://github.com/QuEraComputing/bloqade-python/assets/32608115/9e20d7bb-d33b-4deb-8faf-88677172b0fc">
<img width="1085" alt="Screenshot 2023-09-25 at 6 32 02 PM" src="https://github.com/QuEraComputing/bloqade-python/assets/32608115/d9e06002-f08a-4536-8cdb-ed14fc31d509">
<img width="240" alt="Screenshot 2023-09-25 at 6 32 18 PM" src="https://github.com/QuEraComputing/bloqade-python/assets/32608115/a5786ac4-b236-4104-8dfa-37a289564f02">
<img width="241" alt="Screenshot 2023-09-25 at 6 34 56 PM" src="https://github.com/QuEraComputing/bloqade-python/assets/32608115/5f214567-3cf0-407d-a118-dd4675812625">
