### PR TITLE
Added atom_list factory

### DIFF
--- a/src/bloqade/__init__.py
+++ b/src/bloqade/__init__.py
@@ -7,6 +7,7 @@ from bloqade.factory import (
     piecewise_constant,
     linear,
     constant,
+    atom_list,
     rydberg_h,
 )
 import bloqade.ir as _ir
@@ -45,6 +46,7 @@ __all__ = [
     "piecewise_constant",
     "linear",
     "constant",
+    "atom_list",
     "set_print_depth",
     "load",
     "save",

--- a/src/bloqade/factory.py
+++ b/src/bloqade/factory.py
@@ -1,8 +1,14 @@
+# Need to do this because `ruff` complains standard
+# `start` import overshadows the `start` var used in
+# piecewise_linear
+from bloqade import start as bloqade_start
+from bloqade.ir import ListOfLocations
 from bloqade.ir.routine.base import Routine
 from bloqade.ir.control.waveform import Waveform, Linear, Constant
+from bloqade.ir.location.transform import PositionArray, BoolArray
 from bloqade.builder.typing import ScalarType
 from beartype import beartype
-from beartype.typing import List, Optional, Union, Dict, Any
+from beartype.typing import List, Tuple, Optional, Union, Dict, Any
 
 
 @beartype
@@ -102,6 +108,36 @@ def piecewise_constant(
             pwc_wf = pwc_wf.append(Constant(value, duration))
 
     return pwc_wf
+
+
+@beartype
+def atom_list(
+    position: Union[
+        PositionArray,
+        List[Tuple[ScalarType, ScalarType]],
+        Tuple[ScalarType, ScalarType],
+    ],
+    filling: Optional[Union[BoolArray, List[bool], bool]] = None,
+) -> ListOfLocations:
+    """Create a `ListOfLocations` object, the standard object
+    Bloqade uses to represent atom positions.
+
+    Args:
+        position: (Tuple[ScalarType, ScalarType]
+        | List[Tuple[ScalarType, ScalarType]
+        | numpy.array with shape (n, 2)]):
+            position(s) to add
+        filling: (bool | list[bool]
+        | numpy.array with shape (n, ) | None, optional):
+            filling of the added position(s). Defaults to None. if None, all
+            positions are filled.
+
+
+    Returns:
+        ListOfLocations: new atom arrangement with positions
+
+    """
+    return bloqade_start.add_position(position, filling)
 
 
 @beartype

--- a/src/bloqade/factory.py
+++ b/src/bloqade/factory.py
@@ -1,7 +1,3 @@
-# Need to do this because `ruff` complains standard
-# `start` import overshadows the `start` var used in
-# piecewise_linear
-from bloqade import start as bloqade_start
 from bloqade.ir import ListOfLocations
 from bloqade.ir.routine.base import Routine
 from bloqade.ir.control.waveform import Waveform, Linear, Constant
@@ -137,7 +133,7 @@ def atom_list(
         ListOfLocations: new atom arrangement with positions
 
     """
-    return bloqade_start.add_position(position, filling)
+    return ListOfLocations().add_position(position, filling)
 
 
 @beartype

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -6,6 +6,7 @@ from bloqade import (
     piecewise_constant,
     constant,
     linear,
+    atom_list,
     var,
     cast,
     start,
@@ -20,10 +21,14 @@ from bloqade.ir import (
     detuning,
     Field,
     Uniform,
+    ListOfLocations,
+    Literal,
 )
 from bloqade.ir.routine.base import Routine
 from bloqade.ir.routine.params import Params
+from bloqade.ir.location.base import LocationInfo
 import numpy as np
+from decimal import Decimal
 
 
 def test_ir_piecewise_linear():
@@ -163,3 +168,67 @@ def test_rydberg_h_2():
     print(AnalogCircuit(register, sequence))
 
     assert prog.parse_circuit() == AnalogCircuit(register, sequence)
+
+
+def test_atom_list():
+    al = atom_list((0, 0))
+    assert al == ListOfLocations(
+        [LocationInfo((Literal(value=Decimal("0")), Literal(value=Decimal("0"))), True)]
+    )
+
+    al = atom_list((0, 0), False)
+    assert al == ListOfLocations(
+        [
+            LocationInfo(
+                (Literal(value=Decimal("0")), Literal(value=Decimal("0"))), False
+            )
+        ]
+    )
+
+    al = atom_list([(0, 0), (1, 1)])
+    assert al == ListOfLocations(
+        location_list=[
+            LocationInfo(
+                (Literal(value=Decimal("0")), Literal(value=Decimal("0"))), True
+            ),
+            LocationInfo(
+                (Literal(value=Decimal("1")), Literal(value=Decimal("1"))), True
+            ),
+        ]
+    )
+
+    al = atom_list([(0, 0), (1, 1)], [True, False])
+    assert al == ListOfLocations(
+        location_list=[
+            LocationInfo(
+                (Literal(value=Decimal("0")), Literal(value=Decimal("0"))), True
+            ),
+            LocationInfo(
+                (Literal(value=Decimal("1")), Literal(value=Decimal("1"))), False
+            ),
+        ]
+    )
+
+    al = atom_list(np.array([(0, 0), (1, 1)]))
+    assert al == ListOfLocations(
+        location_list=[
+            LocationInfo(
+                (Literal(value=Decimal("0")), Literal(value=Decimal("0"))), True
+            ),
+            LocationInfo(
+                (Literal(value=Decimal("1")), Literal(value=Decimal("1"))), True
+            ),
+        ]
+    )
+
+    al = atom_list(np.array([(0, 0), (1, 1)]), np.array([True, False]))
+    assert al == ListOfLocations(
+        location_list=[
+            LocationInfo(
+                (Literal(value=Decimal("0")), Literal(value=Decimal("0"))), True
+            ),
+            LocationInfo(
+                (Literal(value=Decimal("1")), Literal(value=Decimal("1"))), False
+            ),
+        ]
+    )


### PR DESCRIPTION
This was suggested by @plquera but considering we have factory functions for waveforms it would be nice to carry that functionality over to atom positions. 

If waveforms allow you to build them independently so should geometries. Without this users would have to go to the plain `ListOfLocations` object in the IR which is rather cumbersome. 

All I've done here is aliased `start.add_position` which already handles the decent variety of argument types to an `atom_list` function. 