### PR TITLE
Fix for `Record` waveform node visualization. 

### DIFF
--- a/src/bloqade/ir/control/waveform.py
+++ b/src/bloqade/ir/control/waveform.py
@@ -98,7 +98,6 @@ class Waveform:
         Returns:
             figure: a bokeh figure
         """
-
         return get_ir_figure(self, **assignments)
 
     def _get_data(self, npoints, **assignments):

--- a/src/bloqade/ir/control/waveform.py
+++ b/src/bloqade/ir/control/waveform.py
@@ -98,9 +98,14 @@ class Waveform:
         Returns:
             figure: a bokeh figure
         """
+
         return get_ir_figure(self, **assignments)
 
     def _get_data(self, npoints, **assignments):
+        from bloqade.ir.analysis.assignment_scan import AssignmentScanRecord
+
+        assignments = AssignmentScanRecord(assignments).emit(self)
+
         duration = float(self.duration(**assignments))
         times = np.linspace(0, duration, npoints + 1)
         values = [self.__call__(time, **assignments) for time in times]


### PR DESCRIPTION
Currently having a `Record` node in the Waveform IR breaks the visualization because there is no scan done to fix-up the value of the record variables. This PR add that in the methods used to generate the plot data for the waveform. 