### PR TITLE
feat: add user agent string

### DIFF
--- a/src/bloqade/submission/braket.py
+++ b/src/bloqade/submission/braket.py
@@ -10,6 +10,7 @@ from bloqade.submission.ir.task_results import (
 )
 from bloqade.submission.ir.task_specification import QuEraTaskSpecification
 from braket.aws import AwsDevice, AwsQuantumTask
+import bloqade
 
 
 class BraketBackend(SubmissionBackend):
@@ -17,7 +18,10 @@ class BraketBackend(SubmissionBackend):
 
     @property
     def device(self) -> AwsDevice:
-        return AwsDevice(self.device_arn)
+        device = AwsDevice(self.device_arn)
+        user_agent = f"Bloqade/{bloqade.__version__}"
+        device.aws_session.add_braket_user_agent(user_agent)
+        return device
 
     def submit_task(self, task_ir: QuEraTaskSpecification) -> str:
         shots, ahs_program = to_braket_task(task_ir)

--- a/tests/test_braket_submission_backend.py
+++ b/tests/test_braket_submission_backend.py
@@ -49,6 +49,16 @@ def test_braket_submit(*args, **kwargs):
     mock_aws_device.run.assert_called_once()
 
 
+@patch("bloqade.submission.braket.AwsDevice")
+def test_add_braket_user_agent_invoked(*args, **kwargs):
+    backend = bloqade.submission.braket.BraketBackend()
+    expected_user_agent = f"Bloqade/{bloqade.__version__}"
+
+    backend.device.aws_session.add_braket_user_agent.assert_called_with(
+        expected_user_agent
+    )
+
+
 @pytest.mark.skip(
     reason="removed implementation for validation because of issue with empty queue."
 )


### PR DESCRIPTION
The Amazon Braket SDK supports integrations with popular quantum computing frameworks. This PR updates the [user agent header](https://datatracker.ietf.org/doc/html/rfc7231#section-5.5.3) to include version information for your integration. An example can be found [here](https://github.com/amazon-braket/amazon-braket-pennylane-plugin-python/commit/ccee35604afc2b04d83ee9103eccb2821a4256cb).