### PR TITLE
renaming field to `magnitude`.

### DIFF
--- a/src/bloqade/codegen/hardware/quera.py
+++ b/src/bloqade/codegen/hardware/quera.py
@@ -154,7 +154,7 @@ class AHSCodegenResult:
                         if self.lattice_site_coefficients is None
                         else [
                             ir.ShiftingField(
-                                amplitude=ir.PhysicalField(
+                                magnitude=ir.PhysicalField(
                                     time_series=ir.TimeSeries(
                                         times=list(
                                             map(


### PR DESCRIPTION
- Simple fix, use the wrong argument when specifying the `ShiftingField` constructor. 