### PR TITLE
Converting Units of Capabilities.

### DIFF
--- a/src/bloqade/__init__.py
+++ b/src/bloqade/__init__.py
@@ -3,6 +3,7 @@ from bloqade.ir import to_waveform as waveform
 from bloqade.serialize import load, save, loads, dumps
 
 from bloqade.factory import (
+    get_capabilities,
     piecewise_linear,
     piecewise_constant,
     linear,
@@ -11,7 +12,6 @@ from bloqade.factory import (
 )
 import bloqade.ir as _ir
 from bloqade.constants import RB_C6
-from bloqade.submission.capabilities import get_capabilities
 
 import importlib.metadata
 

--- a/src/bloqade/codegen/hardware/quera.py
+++ b/src/bloqade/codegen/hardware/quera.py
@@ -517,8 +517,10 @@ class AHSCodegen(AnalogCircuitVisitor):
                 "Cannot parallelize register without device capabilities."
             )
 
-        height_max = self.capabilities.capabilities.lattice.area.height / 1e-6
-        width_max = self.capabilities.capabilities.lattice.area.width / 1e-6
+        height_max = self.capabilities.capabilities.lattice.area.height / Decimal(
+            "1e-6"
+        )
+        width_max = self.capabilities.capabilities.lattice.area.width / Decimal("1e-6")
         number_sites_max = (
             self.capabilities.capabilities.lattice.geometry.number_sites_max
         )

--- a/src/bloqade/factory.py
+++ b/src/bloqade/factory.py
@@ -9,6 +9,17 @@ if TYPE_CHECKING:
 
 
 def get_capabilities() -> "QuEraCapabilities":
+    """Get the device capabilities for Aquila
+
+    Returns:
+        QuEraCapabilities: capabilities object for Aquila device.
+
+
+    Note:
+        Units of time, distance, and energy are microseconds (us),
+        micrometers (um), and rad / us, respectively.
+    """
+
     from bloqade.submission.capabilities import get_capabilities
     import bloqade.submission.ir.capabilities as cp
 

--- a/src/bloqade/factory.py
+++ b/src/bloqade/factory.py
@@ -2,7 +2,122 @@ from bloqade.ir.routine.base import Routine
 from bloqade.ir.control.waveform import Waveform, Linear, Constant
 from bloqade.builder.typing import ScalarType
 from beartype import beartype
-from beartype.typing import List, Optional, Union, Dict, Any
+from beartype.typing import TYPE_CHECKING, List, Optional, Union, Dict, Any
+
+if TYPE_CHECKING:
+    from bloqade.submission.ir.capabilities import QuEraCapabilities
+
+
+def get_capabilities() -> "QuEraCapabilities":
+    from bloqade.submission.capabilities import get_capabilities
+    import bloqade.submission.ir.capabilities as cp
+
+    capabilities_schema = get_capabilities()
+
+    capabilities = capabilities_schema.capabilities
+
+    # manually convert to units
+    return cp.QuEraCapabilities(
+        version=capabilities_schema.version,
+        capabilities=cp.DeviceCapabilities(
+            task=cp.TaskCapabilities(
+                number_shots_max=capabilities.task.number_shots_max,
+                number_shots_min=capabilities.task.number_shots_min,
+            ),
+            lattice=cp.LatticeCapabilities(
+                number_qubits_max=capabilities.lattice.number_qubits_max,
+                area=cp.LatticeAreaCapabilities(
+                    width=(capabilities.lattice.area.width * 1e6),  # m
+                    height=(capabilities.lattice.area.height * 1e6),  # m
+                ),
+                geometry=cp.LatticeGeometryCapabilities(
+                    number_sites_max=capabilities.lattice.geometry.number_sites_max,
+                    spacing_radial_min=(
+                        capabilities.lattice.geometry.spacing_radial_min * 1e6
+                    ),  # m
+                    spacing_vertical_min=(
+                        capabilities.lattice.geometry.spacing_vertical_min * 1e6
+                    ),  # m
+                    position_resolution=(
+                        capabilities.lattice.geometry.position_resolution * 1e6
+                    ),  # m
+                ),
+            ),
+            rydberg=cp.RydbergCapabilities(
+                c6_coefficient=capabilities.rydberg.c6_coefficient
+                * (1e30),  # rad * m^6 / s
+                global_=cp.RydbergGlobalCapabilities(
+                    phase_max=(capabilities.rydberg.global_.phase_max),  # rad
+                    phase_min=(capabilities.rydberg.global_.phase_min),  # rad
+                    phase_resolution=(
+                        capabilities.rydberg.global_.phase_resolution
+                    ),  # rad
+                    rabi_frequency_max=(
+                        capabilities.rydberg.global_.rabi_frequency_max / 1e6
+                    ),  # rad / s
+                    rabi_frequency_min=(
+                        capabilities.rydberg.global_.rabi_frequency_min / 1e6
+                    ),  # rad / s
+                    rabi_frequency_resolution=(
+                        capabilities.rydberg.global_.rabi_frequency_resolution / 1e6
+                    ),  # rad / s
+                    rabi_frequency_slew_rate_max=(
+                        capabilities.rydberg.global_.rabi_frequency_slew_rate_max
+                        / 1e6**2
+                    ),  # rad / s^2
+                    detuning_max=(
+                        capabilities.rydberg.global_.detuning_max / 1e6
+                    ),  # rad / s
+                    detuning_min=(
+                        capabilities.rydberg.global_.detuning_min / 1e6
+                    ),  # rad / s
+                    detuning_resolution=(
+                        capabilities.rydberg.global_.detuning_resolution / 1e6
+                    ),  # rad / s
+                    detuning_slew_rate_max=(
+                        capabilities.rydberg.global_.detuning_slew_rate_max / 1e6**2
+                    ),  # rad / s^2
+                    time_min=(capabilities.rydberg.global_.time_min * 1e6),  # s
+                    time_max=(capabilities.rydberg.global_.time_max * 1e6),  # s
+                    time_resolution=(
+                        capabilities.rydberg.global_.time_resolution * 1e6
+                    ),  # s
+                    time_delta_min=(
+                        capabilities.rydberg.global_.time_delta_min * 1e6
+                    ),  # s
+                ),
+                local=cp.RydbergLocalCapabilities(
+                    number_local_detuning_sites=(
+                        capabilities.rydberg.local.number_local_detuning_sites
+                    ),
+                    site_coefficient_max=(
+                        capabilities.rydberg.local.site_coefficient_max
+                    ),
+                    site_coefficient_min=(
+                        capabilities.rydberg.local.site_coefficient_min
+                    ),
+                    spacing_radial_min=(
+                        capabilities.rydberg.local.spacing_radial_min * 1e6
+                    ),  # rad / s
+                    detuning_min=(
+                        capabilities.rydberg.local.detuning_min / 1e6
+                    ),  # rad / s
+                    detuning_max=(
+                        capabilities.rydberg.local.detuning_max / 1e6
+                    ),  # rad / s
+                    detuning_slew_rate_max=(
+                        capabilities.rydberg.local.detuning_slew_rate_max / 1e6**2
+                    ),  # rad / s^2
+                    time_delta_min=(
+                        capabilities.rydberg.local.time_delta_min * 1e6
+                    ),  # s
+                    time_resolution=(
+                        capabilities.rydberg.local.time_resolution * 1e6
+                    ),  # s
+                ),
+            ),
+        ),
+    )
 
 
 @beartype

--- a/src/bloqade/factory.py
+++ b/src/bloqade/factory.py
@@ -3,6 +3,7 @@ from bloqade.ir.control.waveform import Waveform, Linear, Constant
 from bloqade.builder.typing import ScalarType
 from beartype import beartype
 from beartype.typing import TYPE_CHECKING, List, Optional, Union, Dict, Any
+from decimal import Decimal
 
 if TYPE_CHECKING:
     from bloqade.submission.ir.capabilities import QuEraCapabilities
@@ -38,25 +39,28 @@ def get_capabilities() -> "QuEraCapabilities":
             lattice=cp.LatticeCapabilities(
                 number_qubits_max=capabilities.lattice.number_qubits_max,
                 area=cp.LatticeAreaCapabilities(
-                    width=(capabilities.lattice.area.width * 1e6),  # m
-                    height=(capabilities.lattice.area.height * 1e6),  # m
+                    width=(capabilities.lattice.area.width * Decimal("1e6")),  # m
+                    height=(capabilities.lattice.area.height * Decimal("1e6")),  # m
                 ),
                 geometry=cp.LatticeGeometryCapabilities(
                     number_sites_max=capabilities.lattice.geometry.number_sites_max,
                     spacing_radial_min=(
-                        capabilities.lattice.geometry.spacing_radial_min * 1e6
+                        capabilities.lattice.geometry.spacing_radial_min
+                        * Decimal("1e6")
                     ),  # m
                     spacing_vertical_min=(
-                        capabilities.lattice.geometry.spacing_vertical_min * 1e6
+                        capabilities.lattice.geometry.spacing_vertical_min
+                        * Decimal("1e6")
                     ),  # m
                     position_resolution=(
-                        capabilities.lattice.geometry.position_resolution * 1e6
+                        capabilities.lattice.geometry.position_resolution
+                        * Decimal("1e6")
                     ),  # m
                 ),
             ),
             rydberg=cp.RydbergCapabilities(
                 c6_coefficient=capabilities.rydberg.c6_coefficient
-                * (1e30),  # rad * m^6 / s
+                * Decimal("1e30"),  # rad * m^6 / s
                 global_=cp.RydbergGlobalCapabilities(
                     phase_max=(capabilities.rydberg.global_.phase_max),  # rad
                     phase_min=(capabilities.rydberg.global_.phase_min),  # rad
@@ -64,37 +68,44 @@ def get_capabilities() -> "QuEraCapabilities":
                         capabilities.rydberg.global_.phase_resolution
                     ),  # rad
                     rabi_frequency_max=(
-                        capabilities.rydberg.global_.rabi_frequency_max / 1e6
+                        capabilities.rydberg.global_.rabi_frequency_max / Decimal("1e6")
                     ),  # rad / s
                     rabi_frequency_min=(
-                        capabilities.rydberg.global_.rabi_frequency_min / 1e6
+                        capabilities.rydberg.global_.rabi_frequency_min / Decimal("1e6")
                     ),  # rad / s
                     rabi_frequency_resolution=(
-                        capabilities.rydberg.global_.rabi_frequency_resolution / 1e6
+                        capabilities.rydberg.global_.rabi_frequency_resolution
+                        / Decimal("1e6")
                     ),  # rad / s
                     rabi_frequency_slew_rate_max=(
                         capabilities.rydberg.global_.rabi_frequency_slew_rate_max
-                        / 1e6**2
+                        / Decimal("1e6") ** 2
                     ),  # rad / s^2
                     detuning_max=(
-                        capabilities.rydberg.global_.detuning_max / 1e6
+                        capabilities.rydberg.global_.detuning_max / Decimal("1e6")
                     ),  # rad / s
                     detuning_min=(
-                        capabilities.rydberg.global_.detuning_min / 1e6
+                        capabilities.rydberg.global_.detuning_min / Decimal("1e6")
                     ),  # rad / s
                     detuning_resolution=(
-                        capabilities.rydberg.global_.detuning_resolution / 1e6
+                        capabilities.rydberg.global_.detuning_resolution
+                        / Decimal("1e6")
                     ),  # rad / s
                     detuning_slew_rate_max=(
-                        capabilities.rydberg.global_.detuning_slew_rate_max / 1e6**2
+                        capabilities.rydberg.global_.detuning_slew_rate_max
+                        / Decimal("1e6") ** 2
                     ),  # rad / s^2
-                    time_min=(capabilities.rydberg.global_.time_min * 1e6),  # s
-                    time_max=(capabilities.rydberg.global_.time_max * 1e6),  # s
+                    time_min=(
+                        capabilities.rydberg.global_.time_min * Decimal("1e6")
+                    ),  # s
+                    time_max=(
+                        capabilities.rydberg.global_.time_max * Decimal("1e6")
+                    ),  # s
                     time_resolution=(
-                        capabilities.rydberg.global_.time_resolution * 1e6
+                        capabilities.rydberg.global_.time_resolution * Decimal("1e6")
                     ),  # s
                     time_delta_min=(
-                        capabilities.rydberg.global_.time_delta_min * 1e6
+                        capabilities.rydberg.global_.time_delta_min * Decimal("1e6")
                     ),  # s
                 ),
                 local=cp.RydbergLocalCapabilities(
@@ -108,22 +119,23 @@ def get_capabilities() -> "QuEraCapabilities":
                         capabilities.rydberg.local.site_coefficient_min
                     ),
                     spacing_radial_min=(
-                        capabilities.rydberg.local.spacing_radial_min * 1e6
+                        capabilities.rydberg.local.spacing_radial_min * Decimal("1e6")
                     ),  # rad / s
                     detuning_min=(
-                        capabilities.rydberg.local.detuning_min / 1e6
+                        capabilities.rydberg.local.detuning_min / Decimal("1e6")
                     ),  # rad / s
                     detuning_max=(
-                        capabilities.rydberg.local.detuning_max / 1e6
+                        capabilities.rydberg.local.detuning_max / Decimal("1e6")
                     ),  # rad / s
                     detuning_slew_rate_max=(
-                        capabilities.rydberg.local.detuning_slew_rate_max / 1e6**2
+                        capabilities.rydberg.local.detuning_slew_rate_max
+                        / Decimal("1e6") ** 2
                     ),  # rad / s^2
                     time_delta_min=(
-                        capabilities.rydberg.local.time_delta_min * 1e6
+                        capabilities.rydberg.local.time_delta_min * Decimal("1e6")
                     ),  # s
                     time_resolution=(
-                        capabilities.rydberg.local.time_resolution * 1e6
+                        capabilities.rydberg.local.time_resolution * Decimal("1e6")
                     ),  # s
                 ),
             ),

--- a/src/bloqade/submission/capabilities.py
+++ b/src/bloqade/submission/capabilities.py
@@ -1,4 +1,4 @@
-import json
+import simplejson as json
 import os
 from bloqade.submission.ir.capabilities import QuEraCapabilities
 

--- a/src/bloqade/submission/capabilities.py
+++ b/src/bloqade/submission/capabilities.py
@@ -5,11 +5,6 @@ from bloqade.submission.ir.capabilities import QuEraCapabilities
 
 # TODO: Create unit converter for capabilities
 def get_capabilities() -> QuEraCapabilities:
-    """Get the device capabilities for Aquila
-
-    Returns:
-        QuEraCapabilities: capabilities object for Aquila
-    """
     base_path = os.path.dirname(__file__)
     full_path = os.path.join(
         base_path, "quera_api_client", "config", "capabilities.json"

--- a/src/bloqade/submission/ir/capabilities.py
+++ b/src/bloqade/submission/ir/capabilities.py
@@ -1,40 +1,41 @@
 from pydantic import BaseModel
+from decimal import Decimal
 
 __all__ = ["QuEraCapabilities"]
 
 
 class RydbergGlobalCapabilities(BaseModel):
-    rabi_frequency_min: float
-    rabi_frequency_max: float
-    rabi_frequency_resolution: float
-    rabi_frequency_slew_rate_max: float
-    detuning_min: float
-    detuning_max: float
-    detuning_resolution: float
-    detuning_slew_rate_max: float
-    phase_min: float
-    phase_max: float
-    phase_resolution: float
-    time_min: float
-    time_max: float
-    time_resolution: float
-    time_delta_min: float
+    rabi_frequency_min: Decimal
+    rabi_frequency_max: Decimal
+    rabi_frequency_resolution: Decimal
+    rabi_frequency_slew_rate_max: Decimal
+    detuning_min: Decimal
+    detuning_max: Decimal
+    detuning_resolution: Decimal
+    detuning_slew_rate_max: Decimal
+    phase_min: Decimal
+    phase_max: Decimal
+    phase_resolution: Decimal
+    time_min: Decimal
+    time_max: Decimal
+    time_resolution: Decimal
+    time_delta_min: Decimal
 
 
 class RydbergLocalCapabilities(BaseModel):
-    detuning_min: float
-    detuning_max: float
-    detuning_slew_rate_max: float
-    site_coefficient_min: float
-    site_coefficient_max: float
+    detuning_min: Decimal
+    detuning_max: Decimal
+    detuning_slew_rate_max: Decimal
+    site_coefficient_min: Decimal
+    site_coefficient_max: Decimal
     number_local_detuning_sites: int
-    spacing_radial_min: float
-    time_resolution: float
-    time_delta_min: float
+    spacing_radial_min: Decimal
+    time_resolution: Decimal
+    time_delta_min: Decimal
 
 
 class RydbergCapabilities(BaseModel):
-    c6_coefficient: float
+    c6_coefficient: Decimal
     global_: RydbergGlobalCapabilities
     local: RydbergLocalCapabilities
 
@@ -44,15 +45,15 @@ class RydbergCapabilities(BaseModel):
 
 
 class LatticeGeometryCapabilities(BaseModel):
-    spacing_radial_min: float
-    spacing_vertical_min: float
-    position_resolution: float
+    spacing_radial_min: Decimal
+    spacing_vertical_min: Decimal
+    position_resolution: Decimal
     number_sites_max: int
 
 
 class LatticeAreaCapabilities(BaseModel):
-    width: float
-    height: float
+    width: Decimal
+    height: Decimal
 
 
 class LatticeCapabilities(BaseModel):

--- a/src/bloqade/submission/quera_api_client/api.py
+++ b/src/bloqade/submission/quera_api_client/api.py
@@ -1,4 +1,4 @@
-import json
+import simplejson as json
 import logging
 import uuid
 from typing import Optional, Union, Dict, Tuple
@@ -49,7 +49,7 @@ class ApiRequest:
         self.logger = logging.getLogger(self.__class__.__name__)
 
     @staticmethod
-    def _result_as_json(result: requests.Response) -> Dict:
+    def _result_as_json(result: requests.Response, **options) -> Dict:
         content_type = result.headers["Content-Type"]
         if content_type != "application/json":
             raise ApiRequest.InvalidResponseError(
@@ -59,7 +59,7 @@ class ApiRequest:
         if len(result.content) == 0:
             return {}
 
-        return json.loads(result.content)
+        return json.loads(result.content, **options)
 
     def _generate_headers(self, base: Optional[dict] = None) -> Dict:
         if base is None:
@@ -375,7 +375,7 @@ class QueueApi:
             self.logger.error(message)
             raise QueueApi.QueueApiError(message)
 
-        return ApiRequest._result_as_json(result)
+        return ApiRequest._result_as_json(result, use_decimal=True)
 
     def validate_task(self, task_json: Union[str, dict]) -> None:
         result = self.api_http_request.post("task", "validate", content=task_json)

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -9,6 +9,7 @@ from bloqade import (
     var,
     cast,
     start,
+    get_capabilities,
 )
 from bloqade.atom_arrangement import Chain
 from bloqade.ir import (
@@ -24,6 +25,78 @@ from bloqade.ir import (
 from bloqade.ir.routine.base import Routine
 from bloqade.ir.routine.params import Params
 import numpy as np
+from decimal import Decimal
+
+
+def test_get_capabilities():
+    capabilities = get_capabilities()
+
+    assert capabilities.version == "0.6"
+    assert capabilities.capabilities.task.number_shots_min == 1
+    assert capabilities.capabilities.task.number_shots_max == 1000
+    assert capabilities.capabilities.lattice.number_qubits_max == 256
+    assert capabilities.capabilities.lattice.area.width == Decimal("75.0")
+    assert capabilities.capabilities.lattice.area.height == Decimal("76.0")
+    assert capabilities.capabilities.lattice.geometry.spacing_radial_min == Decimal(
+        "4.0"
+    )
+    assert capabilities.capabilities.lattice.geometry.spacing_vertical_min == Decimal(
+        "4.0"
+    )
+    assert capabilities.capabilities.lattice.geometry.position_resolution == Decimal(
+        "0.1"
+    )
+    assert capabilities.capabilities.lattice.geometry.number_sites_max == 256
+    assert capabilities.capabilities.rydberg.c6_coefficient == Decimal("5.42e6")
+    assert capabilities.capabilities.rydberg.global_.rabi_frequency_min == Decimal(
+        "0.0"
+    )
+    assert capabilities.capabilities.rydberg.global_.rabi_frequency_max == Decimal(
+        "15.8"
+    )
+    assert (
+        capabilities.capabilities.rydberg.global_.rabi_frequency_resolution
+        == Decimal("4.0e-4")
+    )
+    assert (
+        capabilities.capabilities.rydberg.global_.rabi_frequency_slew_rate_max
+        == Decimal("250.0")
+    )
+    assert capabilities.capabilities.rydberg.global_.detuning_min == Decimal("-125.0")
+    assert capabilities.capabilities.rydberg.global_.detuning_max == Decimal("125.0")
+    assert capabilities.capabilities.rydberg.global_.detuning_resolution == Decimal(
+        "2.0e-7"
+    )
+    assert capabilities.capabilities.rydberg.global_.detuning_slew_rate_max == Decimal(
+        "2500.0"
+    )
+    assert capabilities.capabilities.rydberg.global_.phase_min == Decimal("-99.0")
+    assert capabilities.capabilities.rydberg.global_.phase_max == Decimal("99.0")
+    assert capabilities.capabilities.rydberg.global_.phase_resolution == Decimal(
+        "5.0E-7"
+    )
+    assert capabilities.capabilities.rydberg.global_.time_min == Decimal("0.0")
+    assert capabilities.capabilities.rydberg.global_.time_max == Decimal("4.0")
+    assert capabilities.capabilities.rydberg.global_.time_resolution == Decimal("1e-3")
+    assert capabilities.capabilities.rydberg.global_.time_delta_min == Decimal("5e-2")
+    assert capabilities.capabilities.rydberg.local.detuning_min == Decimal("0.0")
+    assert capabilities.capabilities.rydberg.local.detuning_max == Decimal("125.0")
+    assert capabilities.capabilities.rydberg.local.detuning_slew_rate_max == Decimal(
+        "1.2566e3"
+    )
+    assert capabilities.capabilities.rydberg.local.site_coefficient_min == Decimal(
+        "0.0"
+    )
+    assert capabilities.capabilities.rydberg.local.site_coefficient_max == Decimal(
+        "1.0"
+    )
+    assert (
+        capabilities.capabilities.rydberg.local.number_local_detuning_sites
+        == Decimal("200")
+    )
+    assert capabilities.capabilities.rydberg.local.spacing_radial_min == Decimal("5.0")
+    assert capabilities.capabilities.rydberg.local.time_resolution == Decimal("1e-3")
+    assert capabilities.capabilities.rydberg.local.time_delta_min == Decimal("5e-2")
 
 
 def test_ir_piecewise_linear():

--- a/tests/test_quera_internal_api.py
+++ b/tests/test_quera_internal_api.py
@@ -3,7 +3,7 @@ import bloqade.submission.quera_api_client.api
 from bloqade.submission.base import get_capabilities
 from unittest.mock import patch
 from requests import Response
-import json
+import simplejson as json
 from typing import Dict
 
 from bloqade import start


### PR DESCRIPTION
- moving `get_capabilities` public API to `bloqade.factory`
- Updating docs to discuss units of capabilities. 