### PR TITLE
Adding Method that only pulls results not included in job.  

### DIFF
--- a/src/bloqade/task/batch.py
+++ b/src/bloqade/task/batch.py
@@ -303,6 +303,27 @@ class RemoteBatch(Serializable):
 
         return self
 
+    def retrieve(self) -> "RemoteBatch":
+        """Retrieve missing task results.
+
+        Note:
+            Fetching will update the status of tasks,
+            and only pull the results for those tasks
+            that have completed.
+
+        Return:
+            self
+
+        """
+        # partially online, sometimes blocking
+        # pull the results for tasks that have
+        # not been pulled already.
+        for task in self.tasks.values():
+            if not task._result_exists():
+                task.pull()
+
+        return self
+
     def pull(self) -> "RemoteBatch":
         """
         Pull results of the tasks in the Batch.


### PR DESCRIPTION
Currently `pull` will always call remote API regardless if results exist and `fetch()` will only get results that are not currently there but is non-blocking `retrieve` is a combination of both of these, it will hold when results are missing but only fetch results that haven't been fetched yet. 