### PR TITLE
Changing Bravais Lattice API and Fixing readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ adiabatic_durations = [0.4, 3.2, 0.4]
 max_detuning = var("max_detuning")
 # ...or implicitly inside the program definition.
 adiabatic_program = (
-    Square(3, "lattice_spacing")
+    Square(3, lattice_spacing="lattice_spacing")
     .rydberg.rabi.amplitude.uniform.piecewise_linear(
         durations=adiabatic_durations, values=[0.0, "max_rabi", "max_rabi", 0.0]
     )
@@ -127,42 +127,51 @@ Feel free to let your waveforms grow to your liking too!:
 from bloqade import start
 
 # Save your intermediate steps any way you like
-initial_geometry = start.add_position((0,0))
+initial_geometry = start.add_position((0, 0))
 target_rabi_wf = initial_geometry.rydberg.rabi.amplitude.uniform
-program_1 = target_rabi_wf.piecewise_linear(durations = [0.4, 2.1, 0.4], values = [0, 15.8, 15.8, 0])
+program_1 = target_rabi_wf.piecewise_linear(
+    durations=[0.4, 2.1, 0.4], values=[0, 15.8, 15.8, 0]
+)
 # Tinker with new ideas in a snap
-program_2 = target_rabi_wf.piecewise_linear(durations = [0.5, 1.0, 0.5], values = [0, 10.0, 11.0, 0]).constant(duration = 0.4, value = 5.1)
+program_2 = target_rabi_wf.piecewise_linear(
+    durations=[0.5, 1.0, 0.5], values=[0, 10.0, 11.0, 0]
+).constant(duration=0.4, value=5.1)
 
 ```
 
 Want to focus on building one part of your program first before others (or, just want that same Bloqade.jl flavor?) We've got you covered:
 
 ```python
-from bloqade import piecewise_linear
+from bloqade import piecewise_linear, var
 from bloqade.ir.location import Square
+import numpy as np
 
 # Create a geometry without worrying about pulses yet
-square_lattice = Square(3, "lattice_spacing")
+square_lattice = Square(3, lattice_spacing="lattice_spacing")
 
 # Develop your waveforms any way you like
 
 adiabatic_durations = [0.8, 2.4, 0.8]
-separate_rabi_amp_wf = piecewise_linear(durations = adiabatic_durations, values = [0.0, "max_rabi", "max_rabi", 0.0])
+separate_rabi_amp_wf = piecewise_linear(
+    durations=adiabatic_durations, values=[0.0, "max_rabi", "max_rabi", 0.0]
+)
 
 max_detuning = var("max_detuning")
-separate_rabi_detuning = piecewise_linear(durations = adiabatic_durations, values = [-max_detuning, -max_detuning, max_detuning, max_detuning])
+separate_rabi_detuning = piecewise_linear(
+    durations=adiabatic_durations,
+    values=[-max_detuning, -max_detuning, max_detuning, max_detuning],
+)
 
 # Now bring it all together!
 # And why not sprinkle in some parameter sweeps for fun?
 full_program = (
-    square_lattice.rydberg.rabi.amplitude.uniform
-    .apply(separate_rabi_amp_wf)
-    .detuning.uniform
-    .apply(separate_rabi_detuning)
-    .assign(max_rabi = 15.8,
-            max_detuning = 16.33)
-    .batch_assign(lattice_spacing = np.arange(4.0, 7.0, 0.5),
-                  max_rabi = np.linspace(2 * np.pi * 0.5, 2 * np.pi * 2.5, 6))
+    square_lattice.rydberg.rabi.amplitude.uniform.apply(separate_rabi_amp_wf)
+    .detuning.uniform.apply(separate_rabi_detuning)
+    .assign(max_rabi=15.8, max_detuning=16.33)
+    .batch_assign(
+        lattice_spacing=np.arange(4.0, 7.0, 0.5),
+        max_rabi=np.linspace(2 * np.pi * 0.5, 2 * np.pi * 2.5, 6),
+    )
 )
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bloqade"
-version = "0.12.0"
+version = "0.13.0"
 description = "Neutral atom software development kit"
 authors = [
     {name = "QuEra Computing Inc.", email = "info@quera.com"},

--- a/src/bloqade/ir/location/bravais.py
+++ b/src/bloqade/ir/location/bravais.py
@@ -180,8 +180,9 @@ class Chain(BoundedBravais):
     lattice_spacing: Scalar
     vertical_chain: bool
 
+    @beartype
     def __init__(
-        self, L: int, lattice_spacing: ScalarType = 1.0, vertical_chain: bool = False
+        self, L: int, *, lattice_spacing: ScalarType = 1.0, vertical_chain: bool = False
     ):
         self.L = L
         self.lattice_spacing = cast(lattice_spacing)
@@ -233,8 +234,9 @@ class Square(BoundedBravais):
     L2: int
     lattice_spacing: Scalar
 
+    @beartype
     def __init__(
-        self, L1: int, L2: Optional[int] = None, lattice_spacing: ScalarType = 1.0
+        self, L1: int, L2: Optional[int] = None, *, lattice_spacing: ScalarType = 1.0
     ):
         if L2 is None:
             L2 = L1
@@ -289,10 +291,12 @@ class Rectangular(BoundedBravais):
     lattice_spacing_x: Scalar
     lattice_spacing_y: Scalar
 
+    @beartype
     def __init__(
         self,
         width: int,
         height: int,
+        *,
         lattice_spacing_x: ScalarType = 1.0,
         lattice_spacing_y: ScalarType = 1.0,
     ):
@@ -409,7 +413,7 @@ class Honeycomb(BoundedBravais):
 
     @beartype
     def __init__(
-        self, L1: int, L2: Optional[int] = None, lattice_spacing: ScalarType = 1.0
+        self, L1: int, L2: Optional[int] = None, *, lattice_spacing: ScalarType = 1.0
     ):
         if L2 is None:
             L2 = L1
@@ -466,7 +470,7 @@ class Triangular(BoundedBravais):
 
     @beartype
     def __init__(
-        self, L1: int, L2: Optional[int] = None, lattice_spacing: ScalarType = 1.0
+        self, L1: int, L2: Optional[int] = None, *, lattice_spacing: ScalarType = 1.0
     ):
         if L2 is None:
             L2 = L1
@@ -523,7 +527,7 @@ class Lieb(BoundedBravais):
 
     @beartype
     def __init__(
-        self, L1: int, L2: Optional[int] = None, lattice_spacing: ScalarType = 1.0
+        self, L1: int, L2: Optional[int] = None, *, lattice_spacing: ScalarType = 1.0
     ):
         if L2 is None:
             L2 = L1
@@ -578,7 +582,7 @@ class Kagome(BoundedBravais):
 
     @beartype
     def __init__(
-        self, L1: int, L2: Optional[int] = None, lattice_spacing: ScalarType = 1.0
+        self, L1: int, L2: Optional[int] = None, *, lattice_spacing: ScalarType = 1.0
     ):
         if L2 is None:
             L2 = L1

--- a/tests/test_assign.py
+++ b/tests/test_assign.py
@@ -19,7 +19,7 @@ import pytest
 
 
 def test_assignment():
-    lattice = Chain(2, 4.5)
+    lattice = Chain(2, lattice_spacing=4.5)
     circuit = (
         lattice.rydberg.detuning.scale("amp")
         .piecewise_linear([0.1, 0.5, 0.1], [1.0, 2.0, 3.0, 4.0])
@@ -52,7 +52,7 @@ def test_assignment():
 
 
 def test_assignment_error():
-    lattice = Chain(2, 4.5)
+    lattice = Chain(2, lattice_spacing=4.5)
     circuit = (
         lattice.rydberg.detuning.scale("amp")
         .piecewise_linear([0.1, 0.5, 0.1], [1.0, 2.0, 3.0, 4.0])

--- a/tests/test_is_constant.py
+++ b/tests/test_is_constant.py
@@ -4,7 +4,7 @@ from bloqade.ir.analysis.is_constant import IsConstant
 
 def test_happy_path():
     circuit = (
-        Chain(8, 6.1)
+        Chain(8, lattice_spacing=6.1)
         .rydberg.detuning.uniform.constant(1.0, 10.0)
         .amplitude.uniform.linear(1.0, 1.0, 5.0)
         .linear(1.0, 1.0, 5.0)
@@ -15,7 +15,7 @@ def test_happy_path():
     assert IsConstant().scan(circuit)
 
     circuit = (
-        Chain(8, 6.1)
+        Chain(8, lattice_spacing=6.1)
         .rydberg.detuning.uniform.constant(1.0, 5.0)
         .uniform.constant(1.0, 10.0)
         .slice(2.5, 7.5)
@@ -33,7 +33,7 @@ def test_happy_path():
 
 def test_fail_shape():
     circuit = (
-        Chain(8, 6.1)
+        Chain(8, lattice_spacing=6.1)
         .rydberg.detuning.uniform.constant(1.0, 5.0)
         .uniform.constant(1.0, 10.0)
         .slice(2.5, 7.5)
@@ -49,7 +49,7 @@ def test_fail_shape():
     assert not IsConstant().scan(circuit)
 
     circuit = (
-        Chain(8, 6.1)
+        Chain(8, lattice_spacing=6.1)
         .rydberg.detuning.uniform.constant(1.0, 5.0)
         .uniform.constant(1.0, 10.0)
         .slice(2.5, 7.5)
@@ -69,7 +69,7 @@ def test_fail_shape():
 
 def test_fail_duration():
     circuit = (
-        Chain(8, 6.1)
+        Chain(8, lattice_spacing=6.1)
         .rydberg.detuning.uniform.constant(1.0, 9.0)
         .amplitude.uniform.linear(1.0, 1.0, 5.0)
         .linear(1.0, 1.0, 5.0)
@@ -82,7 +82,7 @@ def test_fail_duration():
     assert not IsConstant().scan(circuit)
 
     circuit = (
-        Chain(8, 6.1)
+        Chain(8, lattice_spacing=6.1)
         .rydberg.detuning.uniform.constant(1.0, 10.0)
         .uniform.constant(1.0, 9.0)
         .amplitude.uniform.linear(1.0, 1.0, 5.0)
@@ -98,7 +98,7 @@ def test_fail_duration():
 
 def test_fail_value():
     circuit = (
-        Chain(8, 6.1)
+        Chain(8, lattice_spacing=6.1)
         .rydberg.detuning.uniform.constant(1.0, 10.0)
         .constant(1.1, 10.0)
         .parse_circuit()

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -8,7 +8,7 @@ import pytest
 def test_batch_error(*args):
     with pytest.raises(RemoteBatch.SubmissionException):
         (
-            Chain(5, 6.1)
+            Chain(5, lattice_spacing=6.1)
             .rydberg.detuning.uniform.linear(-10, 10, 3.0)
             .quera.mock(submission_error=True)
             .run_async(100)
@@ -28,7 +28,7 @@ def test_batch_error(*args):
 def test_batch_warn():
     with pytest.warns():
         (
-            Chain(5, 6.1)
+            Chain(5, lattice_spacing=6.1)
             .rydberg.detuning.uniform.linear(-10, 10, 3.0)
             .quera.mock(submission_error=True)
             .run_async(100, ignore_submission_error=True)

--- a/tests/test_variable_scan.py
+++ b/tests/test_variable_scan.py
@@ -14,7 +14,7 @@ def test_1():
         return delta * np.sin(omega * t)
 
     circuit = (
-        Chain(15, "lattice_spacing")
+        Chain(15, lattice_spacing="lattice_spacing")
         .rydberg.detuning.scale("mask")
         .fn(detuning_wf, "t")
         .amplitude.uniform.constant(15, "t")


### PR DESCRIPTION
The reason for making `lattice_spacing` a keyword-only argument for Bravais Lattices is that we added the other dimension as an optional positional argument to retain the old API, however in the old API that second argument refered to the lattice spacing. Just to avoid confusion going forward we should make `lattice_pacing` keyword-only and leave the second dimension as the optional positional argument. 