### PR TITLE
new Rewriter: AssignToLiteral.

### DIFF
--- a/src/bloqade/rewrite/common/assign_to_literal.py
+++ b/src/bloqade/rewrite/common/assign_to_literal.py
@@ -1,0 +1,16 @@
+from beartype.typing import Any
+from bloqade.ir.visitor import BloqadeIRTransformer
+import bloqade.ir.scalar as scalar
+
+
+class AssignToLiteral(BloqadeIRTransformer):
+    """Transform all assigned variables to literals."""
+
+    def visit_scalar_AssignedVariable(self, node: scalar.AssignedVariable):
+        return scalar.Literal(node.value)
+
+    def visit(self, node: Any) -> Any:
+        if isinstance(node, scalar.Scalar):
+            return scalar.Scalar.canonicalize(super().visit(node))
+
+        return super().visit(node)

--- a/tests/test_assign_to_literal.py
+++ b/tests/test_assign_to_literal.py
@@ -1,0 +1,23 @@
+from bloqade import cast, constant
+from bloqade.rewrite.common.assign_to_literal import AssignToLiteral
+from bloqade.rewrite.common.assign_variables import AssignBloqadeIR
+from decimal import Decimal
+
+
+def test_assign_to_literal():
+    a = cast("a")
+    b = cast("b")
+    c = cast("c")
+
+    expr = (a - b) * c / 2.0
+
+    a = Decimal("1.0")
+    b = Decimal("2.0")
+    c = Decimal("3.0")
+
+    wf_expr = constant(1.0, expr)
+
+    new_expr = AssignBloqadeIR(dict(a=a, b=b, c=c)).visit(wf_expr)
+    literal_expr = AssignToLiteral().visit(new_expr)
+
+    assert cast((a - b) * c / Decimal("2.0")) == literal_expr.value


### PR DESCRIPTION
This simple rewriter takes all assigned variables to literals, which can be canonicalized into simpler expressions for execution. 