### PR TITLE
Extend emulation

### DIFF
--- a/src/bloqade/builder/assign.py
+++ b/src/bloqade/builder/assign.py
@@ -74,7 +74,7 @@ class Assign(BatchAssignable, AddArgs, Parallelizable, BackendRoute, AssignBase)
         super().__init__(parent)
 
         circuit = self.parse_circuit()
-        variables = ScanVariables().emit(circuit)
+        variables = ScanVariables().scan(circuit)
 
         self._static_params = CastParams(
             circuit.register.n_sites, variables.scalar_vars, variables.vector_vars
@@ -94,7 +94,7 @@ class BatchAssign(AddArgs, Parallelizable, BackendRoute, AssignBase):
             return
 
         circuit = self.parse_circuit()
-        variables = ScanVariables().emit(circuit)
+        variables = ScanVariables().scan(circuit)
 
         if not len(np.unique(list(map(len, assignments.values())))) == 1:
             raise ValueError(
@@ -125,7 +125,7 @@ class ListAssign(AddArgs, Parallelizable, BackendRoute, AssignBase):
         super().__init__(parent)
 
         circuit = self.parse_circuit()
-        variables = ScanVariables().emit(circuit)
+        variables = ScanVariables().scan(circuit)
         caster = CastParams(
             circuit.register.n_sites, variables.scalar_vars, variables.vector_vars
         )

--- a/src/bloqade/builder/parse/builder.py
+++ b/src/bloqade/builder/parse/builder.py
@@ -233,7 +233,7 @@ class Parser:
 
         circuit = AnalogCircuit(self.register, self.sequence)
 
-        var_res = ScanVariables().emit(circuit)
+        var_res = ScanVariables().scan(circuit)
         # mark vector and scalar arguments
         args_list = [
             (VectorArg(name) if name in var_res.vector_vars else ScalarArg(name))

--- a/src/bloqade/compiler/analysis/common/assignment_scan.py
+++ b/src/bloqade/compiler/analysis/common/assignment_scan.py
@@ -21,6 +21,6 @@ class AssignmentScan(BloqadeIRVisitor):
 
         self.assignments[var.name] = value
 
-    def emit(self, node) -> Dict[str, LiteralType]:
+    def scan(self, node) -> Dict[str, LiteralType]:
         self.visit(node)
         return self.assignments

--- a/src/bloqade/compiler/analysis/common/scan_variables.py
+++ b/src/bloqade/compiler/analysis/common/scan_variables.py
@@ -39,7 +39,7 @@ class ScanVariables(BloqadeIRVisitor):
         if node.name is not None:  # skip literal vectors
             self.assigned_vector_vars.add(node.name)
 
-    def emit(self, node) -> ScanVariableResults:
+    def scan(self, node) -> ScanVariableResults:
         self.visit(node)
         return ScanVariableResults(
             self.scalar_vars,

--- a/src/bloqade/compiler/codegen/emulator_ir.py
+++ b/src/bloqade/compiler/codegen/emulator_ir.py
@@ -362,7 +362,7 @@ class EmulatorProgramCodeGen(BloqadeIRVisitor):
         return target_atoms
 
     def emit(self, circuit: ir.AnalogCircuit) -> EmulatorProgram:
-        self.assignments = AssignmentScan(self.assignments).emit(circuit.sequence)
+        self.assignments = AssignmentScan(self.assignments).scan(circuit.sequence)
         self.is_hyperfine = IsHyperfineSequence().emit(circuit) or self.is_hyperfine
         self.n_atoms = circuit.register.n_atoms
         self.n_sites = circuit.register.n_sites

--- a/src/bloqade/compiler/passes/emulator.py
+++ b/src/bloqade/compiler/passes/emulator.py
@@ -1,0 +1,38 @@
+from bloqade.compiler.analysis.common import ScanChannels, ScanVariables
+from bloqade.compiler.codegen.emulator_ir import EmulatorProgramCodeGen
+from bloqade.compiler.rewrite.common import (
+    AddPadding,
+    FlattenCircuit,
+    AssignBloqadeIR,
+    AssignToLiteral,
+    Canonicalizer,
+)
+
+
+def flatten(circuit):
+    level_couplings = ScanChannels().scan(circuit)
+    circuit = AddPadding(level_couplings).visit(circuit)
+    return FlattenCircuit(level_couplings).visit(circuit)
+
+
+def assign(assignments, circuit):
+    circuit = AssignBloqadeIR(assignments).emit(circuit)
+    assignment_analysis = ScanVariables().emit(circuit)
+
+    if not assignment_analysis.is_assigned:
+        missing_vars = assignment_analysis.scalar_vars.union(
+            assignment_analysis.vector_vars
+        )
+        raise ValueError(
+            "Missing assignments for variables:\n"
+            + ("\n".join(f"{var}" for var in missing_vars))
+            + "\n"
+        )
+
+    return Canonicalizer().visit(AssignToLiteral().visit(circuit))
+
+
+def generate_emulator_ir(circuit, blockade_radius, use_hyperfine):
+    return EmulatorProgramCodeGen(
+        blockade_radius=blockade_radius, use_hyperfine=use_hyperfine
+    ).emit(circuit)

--- a/src/bloqade/compiler/passes/emulator.py
+++ b/src/bloqade/compiler/passes/emulator.py
@@ -11,9 +11,7 @@ from bloqade.compiler.rewrite.common import (
 
 def flatten(circuit):
     level_couplings = ScanChannels().scan(circuit)
-    print(level_couplings)
     circuit = AddPadding(level_couplings=level_couplings).visit(circuit)
-    print(circuit)
     return FlattenCircuit(level_couplings=level_couplings).visit(circuit)
 
 

--- a/src/bloqade/compiler/passes/emulator.py
+++ b/src/bloqade/compiler/passes/emulator.py
@@ -11,8 +11,10 @@ from bloqade.compiler.rewrite.common import (
 
 def flatten(circuit):
     level_couplings = ScanChannels().scan(circuit)
-    circuit = AddPadding(level_couplings).visit(circuit)
-    return FlattenCircuit(level_couplings).visit(circuit)
+    print(level_couplings)
+    circuit = AddPadding(level_couplings=level_couplings).visit(circuit)
+    print(circuit)
+    return FlattenCircuit(level_couplings=level_couplings).visit(circuit)
 
 
 def assign(assignments, circuit):

--- a/src/bloqade/compiler/passes/emulator.py
+++ b/src/bloqade/compiler/passes/emulator.py
@@ -17,7 +17,7 @@ def flatten(circuit):
 
 def assign(assignments, circuit):
     circuit = AssignBloqadeIR(assignments).emit(circuit)
-    assignment_analysis = ScanVariables().emit(circuit)
+    assignment_analysis = ScanVariables().scan(circuit)
 
     if not assignment_analysis.is_assigned:
         missing_vars = assignment_analysis.scalar_vars.union(

--- a/src/bloqade/compiler/passes/hardware/define.py
+++ b/src/bloqade/compiler/passes/hardware/define.py
@@ -101,7 +101,7 @@ def assign_circuit(
     from bloqade.compiler.analysis.common import AssignmentScan, ScanVariables
     from bloqade.compiler.rewrite.common import AssignBloqadeIR
 
-    final_assignments = AssignmentScan(assignments).emit(circuit)
+    final_assignments = AssignmentScan(assignments).scan(circuit)
 
     assigned_circuit = AssignBloqadeIR(final_assignments).visit(circuit)
 

--- a/src/bloqade/compiler/passes/hardware/define.py
+++ b/src/bloqade/compiler/passes/hardware/define.py
@@ -105,7 +105,7 @@ def assign_circuit(
 
     assigned_circuit = AssignBloqadeIR(final_assignments).visit(circuit)
 
-    assignment_analysis = ScanVariables().emit(assigned_circuit)
+    assignment_analysis = ScanVariables().scan(assigned_circuit)
 
     if not assignment_analysis.is_assigned:
         missing_vars = assignment_analysis.scalar_vars.union(

--- a/src/bloqade/compiler/rewrite/common/add_padding.py
+++ b/src/bloqade/compiler/rewrite/common/add_padding.py
@@ -68,14 +68,15 @@ class AddPadding(BloqadeIRTransformer):
             self.field_names = field_names
 
             if lc in node.pulses:
-                p = self.visit(node.pulses[lc])
+                p = node.pulses[lc]
+                diff_duration = node.duration - p.duration
+
+                p = self.visit(p)
+                if diff_duration != scalar.Literal(0):
+                    p = p.append(self.get_empty_pulse(diff_duration))
+
             else:
                 p = self.get_empty_pulse(node.duration)
-
-            diff_duration = node.duration - p.duration
-
-            if diff_duration != scalar.Literal(0):
-                p = p.append(self.get_empty_pulse(diff_duration))
 
             pulses[lc] = p
 

--- a/src/bloqade/ir/control/waveform.py
+++ b/src/bloqade/ir/control/waveform.py
@@ -105,7 +105,7 @@ class Waveform(HashTrait, CanonicalizeTrait):
     def _get_data(self, npoints, **assignments):
         from bloqade.compiler.analysis.common.assignment_scan import AssignmentScan
 
-        assignments = AssignmentScan(assignments).emit(self)
+        assignments = AssignmentScan(assignments).scan(self)
 
         duration = float(self.duration(**assignments))
         times = np.linspace(0, duration, npoints + 1)

--- a/src/bloqade/ir/routine/bloqade.py
+++ b/src/bloqade/ir/routine/bloqade.py
@@ -57,21 +57,18 @@ class BloqadePythonRoutine(RoutineBase):
             )
 
     def _generate_ir(self, args, blockade_radius):
-        from bloqade.compiler.analysis.common.assignment_scan import AssignmentScan
-        from bloqade.compiler.rewrite.common.assign_variables import AssignBloqadeIR
-        from bloqade.compiler.codegen.emulator_ir import EmulatorProgramCodeGen
+        from bloqade.compiler.passes.emulator import (
+            flatten,
+            assign,
+            generate_emulator_ir,
+        )
 
-        circuit, params = self.circuit, self.params
-
-        circuit = AssignBloqadeIR(params.static_params).visit(circuit)
+        params = self.params
+        circuit = flatten(self.circuit)
 
         for task_number, batch_param in enumerate(params.batch_assignments(*args)):
-            record_params = AssignmentScan(batch_param).emit(circuit)
-            final_circuit = AssignBloqadeIR(record_params).visit(circuit)
-            metadata = {**params.static_params, **record_params}
-            emulator_ir = EmulatorProgramCodeGen(blockade_radius=blockade_radius).emit(
-                final_circuit
-            )
+            metadata, final_circuit = assign(batch_param, circuit)
+            emulator_ir = generate_emulator_ir(final_circuit, blockade_radius)
             yield task_number, emulator_ir, metadata
 
     def _compile(

--- a/src/bloqade/ir/routine/bloqade.py
+++ b/src/bloqade/ir/routine/bloqade.py
@@ -67,7 +67,8 @@ class BloqadePythonRoutine(RoutineBase):
         circuit = flatten(self.circuit)
 
         for task_number, batch_param in enumerate(params.batch_assignments(*args)):
-            metadata, final_circuit = assign(batch_param, circuit)
+            assignment = {**params.static_params, **batch_param}
+            metadata, final_circuit = assign(assignment, circuit)
             emulator_ir = generate_emulator_ir(final_circuit, blockade_radius)
             yield task_number, emulator_ir, metadata
 

--- a/tests/test_assign.py
+++ b/tests/test_assign.py
@@ -77,7 +77,7 @@ def test_scan():
 
     params = dict(max=10, t=0.1)
 
-    completed_params = AssignmentScan(params).emit(circuit)
+    completed_params = AssignmentScan(params).scan(circuit)
     completed_circuit = AssignBloqadeIR(completed_params).visit(circuit)
 
     t_assigned = scalar.AssignedVariable("t", 0.1)

--- a/tests/test_variable_scan.py
+++ b/tests/test_variable_scan.py
@@ -32,7 +32,7 @@ def test_1():
         assigned_scalar_vars=set(),
         assigned_vector_vars=set(),
     )
-    assert expected_result == ScanVariables().emit(circuit)
+    assert expected_result == ScanVariables().scan(circuit)
 
 
 def test_2():
@@ -70,4 +70,4 @@ def test_2():
         assigned_scalar_vars=set(),
         assigned_vector_vars=set(),
     )
-    assert expected_result == ScanVariables().emit(circuit)
+    assert expected_result == ScanVariables().scan(circuit)


### PR DESCRIPTION
This PR uses the `Flatten` rewriter to enable support for emulator the full bloqade IR. 