### PR TITLE
removing unused function

### DIFF
--- a/src/bloqade/core/emulate/ir/state_vector.py
+++ b/src/bloqade/core/emulate/ir/state_vector.py
@@ -322,31 +322,6 @@ class RydbergHamiltonian:
         _, var = self.average_and_variance(register, time)
         return var
 
-    @plum.dispatch
-    def expectation_value(  # noqa: F811
-        self, register: np.ndarray, operator: np.ndarray, site_indices: int
-    ) -> complex:
-        """Calculate expectation values of one and two body operators.
-
-        Args:
-            register (np.ndarray): Register to evaluate expectation value with
-            operator (np.ndarray): Operator to take expectation value of.
-            site_indices (int, Tuple[int, int]): site/sites to evaluate `operator` at.
-                It can either a single integer or a tuple of two integers for one and
-                two body operator respectively.
-
-        Raises:
-            ValueError: Error is raised when the dimension of `operator` is not
-            consistent with `site` argument. The size of the operator must fit the
-            size of the local hilbert space of `site` depending on the number of sites
-            and the number of levels inside each atom, e.g. for two site expectation v
-            alue with a three level atom the operator must be a 9 by 9 array.
-
-        Returns:
-            complex: The expectation value.
-        """
-        self._check_register(register)
-
 
 @dataclass(frozen=True)
 class AnalogGate:


### PR DESCRIPTION
This PR removes a function that was not intended to be there. The API was moved to `StateVector` so we are removing it. 