### PR TITLE
Swap constant prop and analysis passes for AHS compiler. 

### DIFF
--- a/src/bloqade/compiler/passes/hardware/__init__.py
+++ b/src/bloqade/compiler/passes/hardware/__init__.py
@@ -1,9 +1,8 @@
 from .define import (
     analyze_channels,
-    add_padding,
+    canonicalize_circuit,
     assign_circuit,
     validate_waveforms,
-    to_literal_and_canonicalize,
     generate_ahs_code,
     generate_quera_ir,
     generate_braket_ir,
@@ -11,10 +10,9 @@ from .define import (
 
 __all__ = [
     "analyze_channels",
-    "add_padding",
+    "canonicalize_circuit",
     "assign_circuit",
     "validate_waveforms",
-    "to_literal_and_canonicalize",
     "generate_ahs_code",
     "generate_quera_ir",
     "generate_braket_ir",

--- a/src/bloqade/compiler/passes/hardware/define.py
+++ b/src/bloqade/compiler/passes/hardware/define.py
@@ -80,6 +80,7 @@ def canonicalize_circuit(
     )
 
     circuit = AddPadding(level_couplings).visit(circuit)
+    # these two passes are equivalent to a constant propagation pass
     circuit = AssignToLiteral().visit(circuit)
     circuit = Canonicalizer().visit(circuit)
 
@@ -179,7 +180,7 @@ def generate_ahs_code(
     level_couplings: Dict,
     circuit: analog_circuit.AnalogCircuit,
 ) -> AHSComponents:
-    """6. generate ahs code
+    """5. generate ahs code
 
     Generates the AHS code for the given circuit. This includes generating the
     lattice data, global detuning, global amplitude, global phase, local

--- a/src/bloqade/ir/routine/base.py
+++ b/src/bloqade/ir/routine/base.py
@@ -8,7 +8,7 @@ from bloqade.ir.routine.params import Params
 
 from pydantic import ConfigDict
 from pydantic.dataclasses import dataclass
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Union, Optional
 
 if TYPE_CHECKING:
     from bloqade.ir.routine.braket import BraketServiceOptions
@@ -27,11 +27,16 @@ class RoutineParse(Parse):
         return self.circuit
 
     def parse(self: "RoutineBase") -> "Routine":
+        if self.source is None:
+            raise ValueError("Cannot parse a routine without a source Builder.")
         return self
 
 
 class RoutineShow(Show):
     def show(self: "RoutineBase", batch_index: int = 0):
+        if self.source is None:
+            raise ValueError("Cannot show a routine without a source Builder.")
+
         return self.source.show(batch_index)
 
 
@@ -40,7 +45,7 @@ __pydantic_dataclass_config__ = ConfigDict(arbitrary_types_allowed=True)
 
 @dataclass(frozen=True, config=__pydantic_dataclass_config__)
 class RoutineBase(RoutineParse, RoutineShow):
-    source: Builder
+    source: Optional[Builder]
     circuit: AnalogCircuit
     params: Params
 

--- a/src/bloqade/ir/routine/braket.py
+++ b/src/bloqade/ir/routine/braket.py
@@ -40,10 +40,9 @@ class BraketHardwareRoutine(RoutineBase):
         ## fall passes here ###
         from bloqade.compiler.passes.hardware import (
             analyze_channels,
-            add_padding,
+            canonicalize_circuit,
             assign_circuit,
             validate_waveforms,
-            to_literal_and_canonicalize,
             generate_ahs_code,
             generate_quera_ir,
         )
@@ -59,10 +58,9 @@ class BraketHardwareRoutine(RoutineBase):
             final_circuit, metadata = assign_circuit(circuit, assignments)
 
             level_couplings = analyze_channels(final_circuit)
-            final_circuit = add_padding(final_circuit, level_couplings)
+            final_circuit = canonicalize_circuit(final_circuit, level_couplings)
 
             validate_waveforms(level_couplings, final_circuit)
-            final_circuit = to_literal_and_canonicalize(final_circuit)
             ahs_components = generate_ahs_code(
                 capabilities, level_couplings, final_circuit
             )
@@ -185,10 +183,9 @@ class BraketLocalEmulatorRoutine(RoutineBase):
         from bloqade.ir import ParallelRegister
         from bloqade.compiler.passes.hardware import (
             analyze_channels,
-            add_padding,
+            canonicalize_circuit,
             assign_circuit,
             validate_waveforms,
-            to_literal_and_canonicalize,
             generate_ahs_code,
             generate_braket_ir,
         )
@@ -208,10 +205,9 @@ class BraketLocalEmulatorRoutine(RoutineBase):
             final_circuit, metadata = assign_circuit(circuit, assignments)
 
             level_couplings = analyze_channels(final_circuit)
-            final_circuit = add_padding(final_circuit, level_couplings)
+            final_circuit = canonicalize_circuit(final_circuit, level_couplings)
 
             validate_waveforms(level_couplings, final_circuit)
-            final_circuit = to_literal_and_canonicalize(final_circuit)
             ahs_components = generate_ahs_code(None, level_couplings, final_circuit)
             braket_task_ir = generate_braket_ir(ahs_components, shots)
 

--- a/src/bloqade/ir/routine/quera.py
+++ b/src/bloqade/ir/routine/quera.py
@@ -54,10 +54,9 @@ class QuEraHardwareRoutine(RoutineBase):
     ) -> RemoteBatch:
         from bloqade.compiler.passes.hardware import (
             analyze_channels,
-            add_padding,
+            canonicalize_circuit,
             assign_circuit,
             validate_waveforms,
-            to_literal_and_canonicalize,
             generate_ahs_code,
             generate_quera_ir,
         )
@@ -72,10 +71,9 @@ class QuEraHardwareRoutine(RoutineBase):
             final_circuit, metadata = assign_circuit(circuit, assignments)
 
             level_couplings = analyze_channels(final_circuit)
-            final_circuit = add_padding(final_circuit, level_couplings)
+            final_circuit = canonicalize_circuit(final_circuit, level_couplings)
 
             validate_waveforms(level_couplings, final_circuit)
-            final_circuit = to_literal_and_canonicalize(final_circuit)
             ahs_components = generate_ahs_code(
                 capabilities, level_couplings, final_circuit
             )

--- a/tests/_test_compiler_passes.py
+++ b/tests/_test_compiler_passes.py
@@ -4,10 +4,9 @@ from bloqade.ir import analog_circuit
 
 from bloqade.compiler.passes.hardware import (
     analyze_channels,
-    add_padding,
+    canonicalize_circuit,
     assign_circuit,
     validate_waveforms,
-    to_literal_and_canonicalize,
     generate_ahs_code,
 )
 
@@ -29,10 +28,9 @@ capabilities = get_capabilities()
 
 
 level_couplings = analyze_channels(circuit)
-circuit = add_padding(circuit, level_couplings)
+circuit = canonicalize_circuit(circuit, level_couplings)
 circuit = assign_circuit(circuit, assignments)
 validate_waveforms(level_couplings, circuit)
-circuit = to_literal_and_canonicalize(circuit)
 ahs_code = generate_ahs_code(capabilities, level_couplings, circuit)
 # 7. specialize to QuEra/Braket IR
 quera_ir, parallel_decoder = ahs_code.generate_quera_ir(shots=100)

--- a/tests/test_braket_emulator.py
+++ b/tests/test_braket_emulator.py
@@ -58,6 +58,18 @@ def test_error():
     assert loads(output_str).name == output.name
 
 
+def check_assign_dur_zero():
+    (
+        start.add_position([(0, 0), (0, 6)])
+        .rydberg.rabi.amplitude.uniform.piecewise_linear(
+            [0.1, "dur", 0.1], [0, 15, 15, 0]
+        )
+        .assign(dur=0)
+        .braket.local_emulator()
+        .run(100)
+    )
+
+
 """
 from bloqade.ir.location import Square
 if __name__ == "__main__":


### PR DESCRIPTION
Currently, the AHS compiler analyzes a partially assigned waveforms. At this stage, the canonicalization pass can't properly eliminate zero-duration segments. The fix here involves swapping the order so that the constant propagation pass is done before the waveforms are  analyzed and validated to be compatible with AHS code generation. 