### PR TITLE
Fix bug in `rydberg_h` where no batch params are passed.

### DIFF
--- a/src/bloqade/ir/routine/params.py
+++ b/src/bloqade/ir/routine/params.py
@@ -62,7 +62,11 @@ class Params:
 
     def batch_assignments(self, *args) -> List[Dict[str, ParamType]]:
         flattened_args = self.parse_args(*args)
-        return [{**flattened_args, **batch} for batch in self.batch_params]
+        if len(self.batch_params) == 0:
+            # handle case where there are no batch params
+            return [flattened_args]
+        else:
+            return [{**flattened_args, **batch} for batch in self.batch_params]
 
     def __str__(self):
         out = ""

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -238,3 +238,24 @@ def test_rydberg_h_2():
     print(AnalogCircuit(register, sequence))
 
     assert prog.parse_circuit() == AnalogCircuit(register, sequence)
+
+
+def test_rydberg_h_3():
+    from bloqade.atom_arrangement import Square
+
+    atom_pos = Square(4, lattice_spacing=5.0)
+
+    # dynamics
+    durations = [0.15, 3.7, 0.15]
+    delta_MHz = [-13.0, -13.0, 11.0, 11.0]
+    omega_MHz = [0.0, 2.5, 2.5, 0.0]
+
+    Delta = piecewise_linear(durations, [x * 2 * np.pi for x in delta_MHz])
+    Omega = piecewise_linear(durations, [x * 2 * np.pi for x in omega_MHz])
+
+    # create Hamiltonian
+    program = rydberg_h(atom_pos, detuning=Delta, amplitude=Omega, phase=None)
+
+    result = program.bloqade.python()._compile(10)
+
+    assert len(result.tasks) == 1


### PR DESCRIPTION
See the test case provided in PR. 