### PR TITLE
Program show bug fix

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,3 +8,5 @@ coverage:
       default:
         target: auto
         threshold: 4%
+codecov:
+ token: 3910fc22-c1a3-4da6-9a0f-a7cfcface6cb

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,6 +8,3 @@ coverage:
       default:
         target: auto
         threshold: 4%
-
-codecov:
-  token: 86b6a2b8-9acb-4b50-b0da-04f14035d704

--- a/src/bloqade/builder/parse/trait.py
+++ b/src/bloqade/builder/parse/trait.py
@@ -56,5 +56,5 @@ class Parse(ParseRegister, ParseSequence, ParseCircuit, ParseRoutine):
 
 
 class Show:
-    def show(self, batch_id: int = 0):
-        display_builder(self, batch_id)
+    def show(self, batch_id: int = 0, *args):
+        display_builder(self, batch_id, *args)

--- a/src/bloqade/builder/parse/trait.py
+++ b/src/bloqade/builder/parse/trait.py
@@ -56,5 +56,5 @@ class Parse(ParseRegister, ParseSequence, ParseCircuit, ParseRoutine):
 
 
 class Show:
-    def show(self, batch_id: int = 0, *args):
+    def show(self, *args, batch_id: int = 0):
         display_builder(self, batch_id, *args)

--- a/src/bloqade/ir/routine/base.py
+++ b/src/bloqade/ir/routine/base.py
@@ -33,11 +33,21 @@ class RoutineParse(Parse):
 
 
 class RoutineShow(Show):
-    def show(self: "RoutineBase", batch_index: int = 0):
+    def show(self: "RoutineBase", batch_index: int = 0, *args):
+        """Show an interactive plot of the routine.
+
+        batch_index: int
+            which parameter set out of the batch to use. Default is 0.
+            If there are no batch parameters, use 0.
+
+        *args: Any
+            Specify the parameters that are defined in the `.args([...])` build step.
+
+        """
         if self.source is None:
             raise ValueError("Cannot show a routine without a source Builder.")
 
-        return self.source.show(batch_index)
+        return self.source.show(batch_index, *args)
 
 
 __pydantic_dataclass_config__ = ConfigDict(arbitrary_types_allowed=True)

--- a/src/bloqade/ir/routine/base.py
+++ b/src/bloqade/ir/routine/base.py
@@ -33,7 +33,7 @@ class RoutineParse(Parse):
 
 
 class RoutineShow(Show):
-    def show(self: "RoutineBase", batch_index: int = 0, *args):
+    def show(self: "RoutineBase", *args, batch_index: int = 0):
         """Show an interactive plot of the routine.
 
         batch_index: int
@@ -47,7 +47,7 @@ class RoutineShow(Show):
         if self.source is None:
             raise ValueError("Cannot show a routine without a source Builder.")
 
-        return self.source.show(batch_index, *args)
+        return self.source.show(*args, batch_id=batch_index)
 
 
 __pydantic_dataclass_config__ = ConfigDict(arbitrary_types_allowed=True)

--- a/src/bloqade/visualization/display.py
+++ b/src/bloqade/visualization/display.py
@@ -87,8 +87,8 @@ def builder_figure(builder, batch_id, *args):
     return row(field, column(reg, div))
 
 
-def display_builder(builder, batch_id):
-    fig = builder_figure(builder, batch_id)
+def display_builder(builder, batch_id, *args):
+    fig = builder_figure(builder, batch_id, *args)
     show(fig)
 
 

--- a/src/bloqade/visualization/display.py
+++ b/src/bloqade/visualization/display.py
@@ -66,7 +66,7 @@ def liner(txt):
     return f"<p>{txt}</p>"
 
 
-def builder_figure(builder, batch_id):
+def builder_figure(builder, batch_id, *args):
     from bloqade.builder.parse.builder import Parser
 
     routine = Parser().parse(builder)
@@ -74,8 +74,8 @@ def builder_figure(builder, batch_id):
     analog_circ = routine.circuit
     metas = routine.params
 
-    kwargs = metas.static_params
-    kwargs.update(metas.batch_params[batch_id])
+    batch_params = metas.batch_assignments(*args)
+    kwargs = batch_params[batch_id]
 
     out = "<p>Assignments: </p>"
     for key, val in kwargs.items():


### PR DESCRIPTION
The API changed from the original definition of `show` for the builder. 

A non-parameterized program breaks the visualization. Similarly if you define parameters with `.args([...])` you can't pass those parameters into show. 

To fix this I have added:
1. Adding `*args` for the show method to capture variables defined via the `.args([...])` build. 
2. using the `Params` object to get the parameters for the batch which fixes the original bug. 