### PR TITLE
Hotfix to relax beartype on numpy type int

### DIFF
--- a/src/bloqade/task/base.py
+++ b/src/bloqade/task/base.py
@@ -195,7 +195,7 @@ class Report:
 
         return bitstrings
 
-    @beartype
+
     def counts(
         self,
         filter_perfect_filling: bool = True,


### PR DESCRIPTION
Users are currently encountering the following when calling `.show` or `.counts` on `Report` objects. 


> BeartypeCallHintReturnViolation: Method bloqade.task.base.Report.counts() return [OrderedDict([('1', 8148), ('0', 1852)]), OrderedDict([('1', 6098), ('0', 3902)]), Ordere...)])] violates type hint list[collections.OrderedDict[str, int]], as list index 6 item <protocol "collections.OrderedDict"> key str '0' value <protocol "numpy.int64"> 9449 not instance of int.

It seems all existing infrastructure works without this check present, I'm unsure of the origin of the problem (I suspect a dependency is doing something considering this was a non-problem before and the last release just modified the pydantic version, not beartype).

