### PR TITLE
Add ability to use experimental capabilities in program submission

### DIFF
--- a/src/bloqade/builder/parse/builder.py
+++ b/src/bloqade/builder/parse/builder.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from bloqade.ir.routine.base import Routine
     from bloqade.ir.analog_circuit import AnalogCircuit
 
+
 class Parser:
     """A class for parsing quantum computing program components into intermediate representation (IR)."""
 

--- a/src/bloqade/builder/parse/stream.py
+++ b/src/bloqade/builder/parse/stream.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from typing import Optional, List, Type
 from bloqade.builder.base import Builder
 
+
 @dataclass
 class BuilderNode:
     """A node in the builder stream."""
@@ -20,6 +21,7 @@ class BuilderNode:
     def __repr__(self) -> str:
         """Representation of the BuilderNode."""
         return repr(self.node)
+
 
 @dataclass
 class BuilderStream:

--- a/src/bloqade/ir/routine/braket.py
+++ b/src/bloqade/ir/routine/braket.py
@@ -34,6 +34,7 @@ class BraketHardwareRoutine(RoutineBase):
     def _compile(
         self,
         shots: int,
+        use_experimental: bool = False,
         args: Tuple[LiteralType, ...] = (),
         name: Optional[str] = None,
     ) -> RemoteBatch:
@@ -47,7 +48,7 @@ class BraketHardwareRoutine(RoutineBase):
             generate_quera_ir,
         )
 
-        capabilities = self.backend.get_capabilities()
+        capabilities = self.backend.get_capabilities(use_experimental)
 
         circuit, params = self.circuit, self.params
 
@@ -85,6 +86,7 @@ class BraketHardwareRoutine(RoutineBase):
         shots: int,
         args: Tuple[LiteralType, ...] = (),
         name: Optional[str] = None,
+        use_experimental: bool = False,
         shuffle: bool = False,
         **kwargs,
     ) -> RemoteBatch:
@@ -99,6 +101,7 @@ class BraketHardwareRoutine(RoutineBase):
             shots (int): number of shots
             args (Tuple): Values of the parameter defined in `args`, defaults to ()
             name (str | None): custom name of the batch, defaults to None
+            use_experimental (bool): Use experimental hardware capabilities
             shuffle (bool): shuffle the order of jobs
 
         Return:
@@ -106,7 +109,7 @@ class BraketHardwareRoutine(RoutineBase):
 
         """
 
-        batch = self._compile(shots, args, name)
+        batch = self._compile(shots, use_experimental, args, name)
         batch._submit(shuffle, **kwargs)
         return batch
 
@@ -116,6 +119,7 @@ class BraketHardwareRoutine(RoutineBase):
         shots: int,
         args: Tuple[LiteralType, ...] = (),
         name: Optional[str] = None,
+        use_experimental: bool = False,
         shuffle: bool = False,
         **kwargs,
     ) -> RemoteBatch:
@@ -139,7 +143,7 @@ class BraketHardwareRoutine(RoutineBase):
 
         """
 
-        batch = self.run_async(shots, args, name, shuffle, **kwargs)
+        batch = self.run_async(shots, args, name, use_experimental, shuffle, **kwargs)
         batch.pull()
         return batch
 

--- a/src/bloqade/ir/routine/braket.py
+++ b/src/bloqade/ir/routine/braket.py
@@ -153,6 +153,7 @@ class BraketHardwareRoutine(RoutineBase):
         *args: LiteralType,
         shots: int = 1,
         name: Optional[str] = None,
+        use_experimental: bool = False,
         shuffle: bool = False,
         **kwargs,
     ):
@@ -175,7 +176,7 @@ class BraketHardwareRoutine(RoutineBase):
             RemoteBatch
 
         """
-        return self.run(shots, args, name, shuffle, **kwargs)
+        return self.run(shots, args, name, use_experimental, shuffle, **kwargs)
 
 
 @dataclass(frozen=True, config=__pydantic_dataclass_config__)

--- a/src/bloqade/ir/routine/quera.py
+++ b/src/bloqade/ir/routine/quera.py
@@ -169,6 +169,7 @@ class QuEraHardwareRoutine(RoutineBase):
     def _compile(
         self,
         shots: int,
+        use_experimental: bool = False,
         args: Tuple[LiteralType, ...] = (),
         name: Optional[str] = None,
     ) -> RemoteBatch:
@@ -182,7 +183,7 @@ class QuEraHardwareRoutine(RoutineBase):
         )
 
         circuit, params = self.circuit, self.params
-        capabilities = self.backend.get_capabilities()
+        capabilities = self.backend.get_capabilities(use_experimental)
 
         tasks = OrderedDict()
 
@@ -218,6 +219,7 @@ class QuEraHardwareRoutine(RoutineBase):
         shots: int,
         args: Tuple[LiteralType, ...] = (),
         name: Optional[str] = None,
+        use_experimental: bool = False, 
         shuffle: bool = False,
         **kwargs,
     ) -> RemoteBatch:
@@ -236,7 +238,7 @@ class QuEraHardwareRoutine(RoutineBase):
             RemoteBatch
 
         """
-        batch = self._compile(shots, args, name)
+        batch = self._compile(shots, use_experimental, args, name)
         batch._submit(shuffle, **kwargs)
         return batch
 
@@ -246,10 +248,11 @@ class QuEraHardwareRoutine(RoutineBase):
         shots: int,
         args: Tuple[LiteralType, ...] = (),
         name: Optional[str] = None,
+        use_experimental: bool = False,
         shuffle: bool = False,
         **kwargs,
     ) -> RemoteBatch:
-        batch = self.run_async(shots, args, name, shuffle, **kwargs)
+        batch = self.run_async(shots, args, name, use_experimental, shuffle, **kwargs)
         batch.pull()
         return batch
 
@@ -259,7 +262,8 @@ class QuEraHardwareRoutine(RoutineBase):
         *args: LiteralType,
         shots: int = 1,
         name: Optional[str] = None,
+        use_experimental: bool = False,
         shuffle: bool = False,
         **kwargs,
     ) -> RemoteBatch:
-        return self.run(shots, args, name, shuffle, **kwargs)
+        return self.run(shots, args, name, use_experimental, shuffle, **kwargs)

--- a/src/bloqade/ir/routine/quera.py
+++ b/src/bloqade/ir/routine/quera.py
@@ -52,6 +52,7 @@ class CustomSubmissionRoutine(RoutineBase):
     def _compile(
         self,
         shots: int,
+        use_experimental: bool = False,
         args: Tuple[LiteralType, ...] = (),
     ):
         from bloqade.compiler.passes.hardware import (
@@ -65,7 +66,7 @@ class CustomSubmissionRoutine(RoutineBase):
         from bloqade.submission.capabilities import get_capabilities
 
         circuit, params = self.circuit, self.params
-        capabilities = get_capabilities()
+        capabilities = get_capabilities(use_experimental)
 
         for batch_params in params.batch_assignments(*args):
             assignments = {**batch_params, **params.static_params}
@@ -92,6 +93,7 @@ class CustomSubmissionRoutine(RoutineBase):
         method: str = "POST",
         args: Tuple[LiteralType] = (),
         request_options: Dict[str, Any] = {},
+        use_experimental: bool = False,
         sleep_time: float = 0.1,
     ) -> List[Tuple[NamedTuple, Response]]:
         """Compile to QuEraTaskSpecification and submit to a custom service.
@@ -110,6 +112,7 @@ class CustomSubmissionRoutine(RoutineBase):
             request_options: additional options to be passed into the request method,
             Note the `data` option will be overwritten by the
             `json_body_template.format(task_ir=task_ir_string)`.
+            use_experimental (bool): Enable experimental hardware capabilities
             sleep_time (float): time to sleep between each request. Defaults to 0.1.
 
         Returns:
@@ -147,7 +150,7 @@ class CustomSubmissionRoutine(RoutineBase):
             )
 
         out = []
-        for metadata, task_ir in self._compile(shots, args):
+        for metadata, task_ir in self._compile(shots, use_experimental, args):
             json_request_body = json_body_template.format(
                 task_ir=task_ir.json(exclude_none=True, exclude_unset=True)
             )

--- a/src/bloqade/ir/routine/quera.py
+++ b/src/bloqade/ir/routine/quera.py
@@ -219,7 +219,7 @@ class QuEraHardwareRoutine(RoutineBase):
         shots: int,
         args: Tuple[LiteralType, ...] = (),
         name: Optional[str] = None,
-        use_experimental: bool = False, 
+        use_experimental: bool = False,
         shuffle: bool = False,
         **kwargs,
     ) -> RemoteBatch:

--- a/src/bloqade/submission/base.py
+++ b/src/bloqade/submission/base.py
@@ -15,8 +15,8 @@ class SubmissionBackend(BaseModel):
     class Config:
         extra = Extra.forbid
 
-    def get_capabilities(self) -> QuEraCapabilities:
-        return get_capabilities()
+    def get_capabilities(self, use_experimental: bool = False) -> QuEraCapabilities:
+        return get_capabilities(use_experimental)
 
     def validate_task(
         self, task_ir: Union[BraketTaskSpecification, QuEraTaskSpecification]

--- a/src/bloqade/submission/braket.py
+++ b/src/bloqade/submission/braket.py
@@ -31,7 +31,7 @@ class BraketBackend(SubmissionBackend):
 
         return self._device
 
-    def get_capabilities(self) -> QuEraCapabilities:
+    def get_capabilities(self, use_experimental: bool = False) -> QuEraCapabilities:
         from botocore.exceptions import BotoCoreError, ClientError
 
         try:
@@ -47,7 +47,7 @@ class BraketBackend(SubmissionBackend):
                 "Using local capabiltiiies file for Aquila."
             )
 
-        return super().get_capabilities()
+        return super().get_capabilities(use_experimental)
 
     def submit_task(self, task_ir: QuEraTaskSpecification) -> str:
         shots, ahs_program = to_braket_task(task_ir)

--- a/src/bloqade/submission/braket.py
+++ b/src/bloqade/submission/braket.py
@@ -42,12 +42,12 @@ class BraketBackend(SubmissionBackend):
         except BotoCoreError:
             warnings.warn(
                 "Could not retrieve device capabilities from braket API. "
-                "Using local capabiltiiies file for Aquila."
+                "Using local capabilities file for Aquila."
             )
         except ClientError:
             warnings.warn(
                 "Could not retrieve device capabilities from braket API. "
-                "Using local capabiltiiies file for Aquila."
+                "Using local capabilities file for Aquila."
             )
 
         return super().get_capabilities()

--- a/src/bloqade/submission/braket.py
+++ b/src/bloqade/submission/braket.py
@@ -34,6 +34,9 @@ class BraketBackend(SubmissionBackend):
     def get_capabilities(self, use_experimental: bool = False) -> QuEraCapabilities:
         from botocore.exceptions import BotoCoreError, ClientError
 
+        if use_experimental:
+            return super().get_capabilities(use_experimental)
+
         try:
             return to_quera_capabilities(self.device.properties.paradigm)
         except BotoCoreError:
@@ -47,7 +50,7 @@ class BraketBackend(SubmissionBackend):
                 "Using local capabiltiiies file for Aquila."
             )
 
-        return super().get_capabilities(use_experimental)
+        return super().get_capabilities()
 
     def submit_task(self, task_ir: QuEraTaskSpecification) -> str:
         shots, ahs_program = to_braket_task(task_ir)

--- a/src/bloqade/submission/quera.py
+++ b/src/bloqade/submission/quera.py
@@ -41,11 +41,11 @@ class QuEraBackend(SubmissionBackend):
 
         return self._queue_api
 
-    def get_capabilities(self) -> QuEraCapabilities:
+    def get_capabilities(self, use_experimental: bool = False) -> QuEraCapabilities:
         try:
             return QuEraCapabilities(**self.queue_api.get_capabilities())
         except BaseException:
-            return super().get_capabilities()
+            return super().get_capabilities(use_experimental)
 
     def submit_task(self, task_ir: QuEraTaskSpecification) -> str:
         return self.queue_api.submit_task(


### PR DESCRIPTION
* `run` and `run_async` under `braket.aquila()` now have a `use_experimental` boolean flag
* `submit` under `quera.custom() also has the `use_experimental` boolean flag