### PR TITLE
Fix Quickstart GIFs

### DIFF
--- a/docs/home/quick_start.md
+++ b/docs/home/quick_start.md
@@ -10,41 +10,25 @@ As you develop your Bloqade program, you are expected to rely on pop-up "hints" 
 
 In [VS Code](https://code.visualstudio.com/) this is automatic, just type the `.` and see what options pop up:
 
-<div align="center">
-<picture>
-  <img src="../assets/quick_start/vscode-hints.gif" alt="VSCode Hints">
-</picture>
-</div>
+![VSCode Hints](../assets/quick_start/vscode-hints.gif)
 
 ### JetBrains PyCharm
 
 The same goes for [JetBrains PyCharm](https://www.jetbrains.com/pycharm/):
 
-<div align="center">
-<picture>
-  <img src="../assets/quick_start/pycharm-hints.gif" alt="PyCharm Hints">
-</picture>
-</div>
+![PyCharm Hints](../assets/quick_start/pycharm-hints.gif)
 
 ### Jupyter Notebook 
 
 In a [Jupyter Notebook](https://jupyter.org/) you'll need to type `.` and then hit tab for the hints to appear:
 
-<div align="center">
-<picture>
-  <img src="../assets/quick_start/jupyter-hints.gif" alt="Jupyter Notebook Hints">
-</picture>
-</div>
+![Jupyter Hints](../assets/quick_start/jupyter-hints.gif)
 
 ### IPython
 
 The same goes for [IPython](https://ipython.readthedocs.io/en/stable/):
 
-<div align="center">
-<picture>
-  <img src="../assets/quick_start/ipython-hints.gif" alt="IPython Hints">
-</picture>
-</div>
+![IPython Hints](../assets/quick_start/ipython-hints.gif)
 
 ## Defining Atom Geometry
 

--- a/docs/home/quick_start.md
+++ b/docs/home/quick_start.md
@@ -12,7 +12,7 @@ In [VS Code](https://code.visualstudio.com/) this is automatic, just type the `.
 
 <div align="center">
 <picture>
-  <img src="/assets/quick_start/vscode-hints.gif" alt="VSCode Hints">
+  <img src="../assets/quick_start/vscode-hints.gif" alt="VSCode Hints">
 </picture>
 </div>
 
@@ -22,7 +22,7 @@ The same goes for [JetBrains PyCharm](https://www.jetbrains.com/pycharm/):
 
 <div align="center">
 <picture>
-  <img src="/assets/quick_start/pycharm-hints.gif" alt="PyCharm Hints">
+  <img src="../assets/quick_start/pycharm-hints.gif" alt="PyCharm Hints">
 </picture>
 </div>
 
@@ -32,7 +32,7 @@ In a [Jupyter Notebook](https://jupyter.org/) you'll need to type `.` and then h
 
 <div align="center">
 <picture>
-  <img src="/assets/quick_start/jupyter-hints.gif" alt="Jupyter Notebook Hints">
+  <img src="../assets/quick_start/jupyter-hints.gif" alt="Jupyter Notebook Hints">
 </picture>
 </div>
 
@@ -42,7 +42,7 @@ The same goes for [IPython](https://ipython.readthedocs.io/en/stable/):
 
 <div align="center">
 <picture>
-  <img src="/assets/quick_start/ipython-hints.gif" alt="IPython Hints">
+  <img src="../assets/quick_start/ipython-hints.gif" alt="IPython Hints">
 </picture>
 </div>
 
@@ -64,7 +64,7 @@ more_complex_geometry.show()
 ```
 <div align="center">
 <picture>
-  <img src="/assets/quick_start/geometry-visualization.png" style="width: 50%" alt="Geometry Visualization">
+  <img src="../assets/quick_start/geometry-visualization.png" style="width: 50%" alt="Geometry Visualization">
 </picture>
 </div>
 

--- a/docs/home/quick_start.md
+++ b/docs/home/quick_start.md
@@ -46,11 +46,10 @@ You can easily visualize your geometries as well with `.show()`:
 ```python
 more_complex_geometry.show()
 ```
-<div align="center">
-<picture>
-  <img src="../assets/quick_start/geometry-visualization.png" style="width: 50%" alt="Geometry Visualization">
-</picture>
-</div>
+<figure markdown="span">
+![IPython Hints](../assets/quick_start/geometry-visualization.png){ width="50%" }
+</figure>
+
 
 You can also add positions to a pre-defined geometry:
 


### PR DESCRIPTION
The GIFs in the quickstart don't seem to render on the live version of the docs, I think this is fixable with the following PR. 

The odd thing is this makes the local rendering via `pdm doc` not work ): 