### PR TITLE
Update Precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,18 +2,18 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v4.6.0
   hooks:
     - id: check-yaml
       args: ['--unsafe']
     - id: end-of-file-fixer
     - id: trailing-whitespace
 - repo: https://github.com/psf/black
-  rev: 24.1.0
+  rev: 24.4.2
   hooks:
     - id: black
 - repo: https://github.com/charliermarsh/ruff-pre-commit
   # Ruff version.
-  rev: "v0.0.264"
+  rev: "v0.5.5"
   hooks:
     - id: ruff

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -131,7 +131,7 @@ def test_scale():
     # print(type(list(seq.pulses.keys())[0]))
     Loc1 = list(seq.pulses[rydberg].fields[detuning].drives.keys())[0]
 
-    assert type(Loc1) == ir.ScaledLocations
+    assert type(Loc1) is ir.ScaledLocations
     assert Loc1.value[ir.Location(1)] == cast(1.2)
 
 
@@ -250,7 +250,7 @@ def test_record():
         .record("detuning")
     )
 
-    assert type(prog) == waveform.Record
+    assert type(prog) is waveform.Record
 
     seq = prog.parse_sequence()
     assert seq.pulses[rydberg].fields[detuning].drives[

--- a/tests/test_lattice.py
+++ b/tests/test_lattice.py
@@ -81,7 +81,7 @@ def test_addlocs_on_square():
     lattice1 = lattice.add_position([(9, 6), (4, 4)])
 
     # type(lattice)
-    assert type(lattice1) == ir.location.ListOfLocations
+    assert type(lattice1) is ir.location.ListOfLocations
 
     positions1 = set(map(lambda info: info.position, lattice1.enumerate()))
     positions_expected1 = set(cast([(0, 0), (1, 0), (0, 1), (1, 1), (9, 6), (4, 4)]))
@@ -94,7 +94,7 @@ def test_addlocs_filling_options():
     lattice = lattice.add_position([(9, 6), (4, 4)], filling=[False, True])
 
     # type(lattice)
-    assert type(lattice) == ir.location.ListOfLocations
+    assert type(lattice) is ir.location.ListOfLocations
 
     for info in lattice.enumerate():
         if info.position == cast((9, 6)):


### PR DESCRIPTION
The CI on #990 is failing because it looks like the precommit YAML is out of sync with what the Github CI uses (the latest version of `ruff`) and as a result `ruff` on the Github CI catches some formatting problem that the local, older version of ruff doesn't catch. 

I went ahead and fixed the code that causes ruff to complain as well as updated the precommit YAML. 